### PR TITLE
Clarify ambiguous briefs before drafting sailing orders

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -10,6 +10,7 @@ Execute this workflow for the user's mission.
 
 ## 1. Issue Sailing Orders
 
+- Review the user's brief for ambiguity. If the outcome, scope, or constraints are unclear, ask the user to clarify before drafting sailing orders.
 - Write one sentence for `outcome`, `metric`, and `deadline`.
 - Set constraints: token budget, reliability floor, compliance rules, and forbidden actions.
 - Define what is out of scope.


### PR DESCRIPTION
## Summary
- Adds an instruction to Step 1 (Issue Sailing Orders) for the admiral to review the user's brief for ambiguity and ask clarifying questions before proceeding.

## Test plan
- [x] Invoke `/nelson` with a vague brief and verify the admiral asks clarifying questions before drafting sailing orders
- [x] Invoke `/nelson` with a clear brief and verify it proceeds without unnecessary questions