### PR TITLE
Sync documentation file trees with current branch state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,16 @@ skills/nelson/
   SKILL.md                — Main entrypoint (what Claude reads)
   references/             — Supporting docs loaded on demand
     action-stations.md      — Risk tier definitions (Station 0–3)
-    admiralty-templates.md   — Index routing to individual template files
     admiralty-templates/     — One file per template, loaded on demand
+    commendations.md        — Recognition signals & graduated correction
     crew-roles.md           — Crew role definitions, ship names & sizing rules
-    damage-control.md       — Index routing to individual procedure files
     damage-control/         — One file per procedure, loaded on demand
+    royal-marines.md        — Royal Marines deployment rules & specialisations
     squadron-composition.md — Mode selection & team sizing rules
-    standing-orders.md      — Index routing to individual anti-pattern files
     standing-orders/        — One file per anti-pattern, loaded on demand
 agents/                   — Agent interface definitions
 demos/                    — Example applications built with Nelson
+scripts/                  — Maintenance scripts
 ```
 
 ## No build system

--- a/README.md
+++ b/README.md
@@ -241,18 +241,17 @@ skills/nelson/
 ├── SKILL.md                                  # Main skill instructions (entrypoint)
 └── references/
     ├── action-stations.md                    # Risk tier definitions and controls
-    ├── admiralty-templates.md                # Template routing index
     ├── admiralty-templates/                  # Individual template files
     │   ├── battle-plan.md
     │   ├── captains-log.md
     │   ├── crew-briefing.md
+    │   ├── marine-deployment-brief.md
     │   ├── quarterdeck-report.md
     │   ├── red-cell-review.md
     │   ├── sailing-orders.md
     │   └── ship-manifest.md
     ├── commendations.md                       # Recognition signals and correction guidance
     ├── crew-roles.md                         # Crew role definitions, ship names, sizing
-    ├── damage-control.md                     # Error recovery routing index
     ├── damage-control/                       # Individual procedure files
     │   ├── crew-overrun.md
     │   ├── escalation.md
@@ -260,11 +259,12 @@ skills/nelson/
     │   ├── partial-rollback.md
     │   ├── scuttle-and-reform.md
     │   └── session-resumption.md
+    ├── royal-marines.md                      # Royal Marines deployment rules
     ├── squadron-composition.md              # Mode selection and team sizing rules
-    ├── standing-orders.md                    # Anti-pattern routing index
     └── standing-orders/                      # Individual anti-pattern files
         ├── admiral-at-the-helm.md
         ├── all-hands-on-deck.md
+        ├── battalion-ashore.md
         ├── becalmed-fleet.md
         ├── captain-at-the-capstan.md
         ├── crew-without-canvas.md

--- a/agents/nelson.md
+++ b/agents/nelson.md
@@ -5,4 +5,4 @@ description: Coordinates multi-agent work using Royal Navy squadron patterns wit
 
 # Nelson
 
-Use $nelson to run a Royal Navy agent mission with sailing orders, action stations, and a captain's log.
+Use /nelson to run a Royal Navy agent mission with sailing orders, action stations, and a captain's log.


### PR DESCRIPTION
## Summary

- Remove references to three deleted index files (`admiralty-templates.md`, `damage-control.md`, `standing-orders.md`) from README and CLAUDE.md file trees
- Add missing entries: `royal-marines.md`, `commendations.md`, `battalion-ashore.md`, `marine-deployment-brief.md`, `scripts/`
- Fix `$nelson` → `/nelson` slash command syntax in `agents/nelson.md`

## Test plan

- [ ] `bash scripts/check-references.sh` passes
- [ ] README file tree matches `ls -R skills/nelson/references/`
- [ ] CLAUDE.md project structure matches repo layout