### PR TITLE
fix: tighten quarterdeck cadence and add report rotation

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -127,7 +127,7 @@ If the task is complete and no pending task depends on it, send `shutdown_reques
         - `press-ganged-navigator.md`: Has the red-cell navigator been assigned implementation work?
         - `all-hands-on-deck.md`: Has any ship mustered crew roles that are idle or unjustified?
         - `battalion-ashore.md`: Has any captain deployed marines for crew work or sustained tasks?
-    - **Write the quarterdeck report to disk** at every checkpoint using `references/admiralty-templates/quarterdeck-report.md`. Do not skip this when hull is Green — compaction can occur at any time and the on-disk report is the only recovery point. Before writing, if `quarterdeck-report.md` already exists in the mission directory, find all files matching `quarterdeck-report-N.md`, determine the next available N (0 if none exist, otherwise one greater than the highest N found), rename the existing file to `quarterdeck-report-N.md`, then write the new report. This keeps the latest report at the canonical path while preserving history.
+    - **Write the quarterdeck report to disk** at every checkpoint using `references/admiralty-templates/quarterdeck-report.md`. Do not skip this when hull is Green — compaction can occur at any time and the on-disk report is the only recovery point. Before writing, if `quarterdeck-report.md` already exists in the working directory, find all files matching `quarterdeck-report-N.md`, determine N as one greater than the highest N found (0 if none exist), rename the existing file to `quarterdeck-report-N.md`, then write the new report. This keeps the latest report at the canonical path while preserving history.
     - Check `TaskList` for any tasks with description prefixed `[AWAITING-ADMIRALTY]:`. If any exist, surface the ask to Admiralty immediately — do not batch to the next checkpoint.
     - Cross-reference the battle plan against `TaskList`: for any task marked `admiralty-action-required: yes` in the battle plan that shows status `completed`, confirm there is a quarterdeck log entry recording admiralty sign-off. If no such entry exists, flag to Admiralty for manual verification — the task may have completed without the intended human step.
 - Re-scope early when a task drifts from mission metric.
@@ -164,7 +164,7 @@ Reference `references/admiralty-templates/red-cell-review.md` for the red-cell r
 ## 6. Stand Down And Log Action
 
 - Stop or archive all agent sessions, including crew.
-- Write the captain's log to a file named `captains-log.md` in the mission working directory. Before writing, if `captains-log.md` already exists, find all files matching `captains-log-N.md`, determine the next available N (0 if none exist, otherwise one greater than the highest N found), rename the existing file to `captains-log-N.md`, then write the new report. The log MUST be written to disk — outputting it to chat only does not satisfy this requirement. The captain's log should contain:
+- Write the captain's log to a file named `captains-log.md` in the mission working directory. Before writing, if `captains-log.md` already exists, find all files matching `captains-log-N.md`, determine N as one greater than the highest N found (0 if none exist), rename the existing file to `captains-log-N.md`, then write the new report. This keeps the latest log at the canonical path while preserving history. The log MUST be written to disk — outputting it to chat only does not satisfy this requirement. The captain's log should contain:
     - Decisions and rationale.
     - Diffs or artifacts.
     - Validation evidence.


### PR DESCRIPTION
## Summary

- Tighten quarterdeck checkpoint cadence from every 2-3 to every 1-2 task completions, ensuring damage reports are persisted more frequently as the sole recovery point after compaction
- Add rename-to-N rotation for `quarterdeck-report.md` and `captains-log.md` so previous reports are preserved rather than overwritten

Addresses feedback from @LannyRipple on #36.

## Test plan

- [ ] Run a multi-task nelson mission and verify quarterdeck checkpoints fire after every 1-2 completions
- [ ] Verify `quarterdeck-report.md` rotates to `quarterdeck-report-0.md` on second checkpoint
- [ ] Verify `captains-log.md` rotates to `captains-log-0.md` when re-running a mission in the same directory