### PR TITLE
fix: move mission artifacts from .claude/nelson/ to .nelson/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ __pycache__/
 *.pyc
 .DS_Store
 .claude/skills/nelson
+.nelson/
 .beans.yml
 .beans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ scripts/                  — Maintenance & utility scripts
 Each Nelson mission creates a timestamped directory for its artifacts:
 
 ```
-.claude/nelson/missions/{YYYY-MM-DD_HHMMSS}/
+.nelson/missions/{YYYY-MM-DD_HHMMSS}/
   captains-log.md         — Written at stand-down
   quarterdeck-report.md   — Updated at every checkpoint
   damage-reports/         — Ship damage reports (JSON)

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ scripts/
 Each mission creates a timestamped directory for its runtime artifacts:
 
 ```
-.claude/nelson/missions/{YYYY-MM-DD_HHMMSS}/
+.nelson/missions/{YYYY-MM-DD_HHMMSS}/
   captains-log.md         — Written at stand-down
   quarterdeck-report.md   — Updated at every checkpoint
   damage-reports/         — Ship damage reports (JSON)

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -29,8 +29,8 @@ Out of scope: Migration script for existing sessions
 ```
 
 **Establish Mission Directory:**
-- **New session:** Create a mission directory at `.claude/nelson/missions/{YYYY-MM-DD_HHMMSS}/` using the current date and time (24-hour format, including seconds). Create the subdirectories `damage-reports/` and `turnover-briefs/` within it. Record the mission directory path and refer to it as `{mission-dir}` for the remainder of this mission.
-- **Resumed session:** List `.claude/nelson/missions/` sorted by name. The most recent directory is the active mission. Set it as `{mission-dir}`. Read `{mission-dir}/quarterdeck-report.md` to recover last known state.
+- **New session:** Create a mission directory at `.nelson/missions/{YYYY-MM-DD_HHMMSS}/` using the current date and time (24-hour format, including seconds). Create the subdirectories `damage-reports/` and `turnover-briefs/` within it. Record the mission directory path and refer to it as `{mission-dir}` for the remainder of this mission.
+- **Resumed session:** List `.nelson/missions/` sorted by name. The most recent directory is the active mission. Set it as `{mission-dir}`. Read `{mission-dir}/quarterdeck-report.md` to recover last known state.
 
 All mission artifacts — captain's log, quarterdeck reports, damage reports, and turnover briefs — are written inside `{mission-dir}`.
 
@@ -223,7 +223,7 @@ Consult the specific procedure that matches the situation.
 
 ## Admiralty Doctrine
 
-- Include this instruction in any admiral's compaction summary: Re-read the quarterdeck report at the mission directory path to recover `{mission-dir}`. If the path is unknown, list `.claude/nelson/missions/` and use the most recent directory. Then re-read `references/standing-orders/admiral-at-the-helm.md` to confirm you are in coordination role.
+- Include this instruction in any admiral's compaction summary: Re-read the quarterdeck report at the mission directory path to recover `{mission-dir}`. If the path is unknown, list `.nelson/missions/` and use the most recent directory. Then re-read `references/standing-orders/admiral-at-the-helm.md` to confirm you are in coordination role.
 - Optimize for mission throughput, not equal work distribution.
 - Prefer replacing stalled agents over waiting on undefined blockers.
 - Recognise strong performance; motivation compounds across missions.

--- a/skills/nelson/references/damage-control/session-hygiene.md
+++ b/skills/nelson/references/damage-control/session-hygiene.md
@@ -4,10 +4,10 @@ Use at the start of a new Nelson session to prepare the mission directory before
 
 ## Directory Structure
 
-Nelson stores each mission's data in a timestamped directory under `.claude/nelson/missions/`:
+Nelson stores each mission's data in a timestamped directory under `.nelson/missions/`:
 
 ```
-.claude/nelson/missions/{YYYY-MM-DD_HHMMSS}/
+.nelson/missions/{YYYY-MM-DD_HHMMSS}/
   captains-log.md         — Written at stand-down
   quarterdeck-report.md   — Updated at every checkpoint
   damage-reports/         — Ship damage reports (JSON)
@@ -28,11 +28,11 @@ The admiral executes session hygiene at Step 1 (Issue Sailing Orders), before fo
 
 ## Procedure: Resumed Session
 
-1. List `.claude/nelson/missions/` sorted by name. The most recent directory is the active mission. Set it as `{mission-dir}`.
+1. List `.nelson/missions/` sorted by name. The most recent directory is the active mission. Set it as `{mission-dir}`.
 2. Read existing damage reports from `{mission-dir}/damage-reports/` to establish hull integrity for each ship.
 3. Read existing turnover briefs from `{mission-dir}/turnover-briefs/` to recover task state.
 4. Follow `damage-control/session-resumption.md` for the full resumption procedure.
 
 ## Browsing Previous Missions
 
-Previous missions remain on disk at `.claude/nelson/missions/`. To review past mission logs, list the directory contents sorted by name (which sorts chronologically by date/time).
+Previous missions remain on disk at `.nelson/missions/`. To review past mission logs, list the directory contents sorted by name (which sorts chronologically by date/time).

--- a/skills/nelson/references/damage-control/session-resumption.md
+++ b/skills/nelson/references/damage-control/session-resumption.md
@@ -2,7 +2,7 @@
 
 Use when a session is interrupted (context limit, crash, timeout) and work must continue.
 
-1. List `.claude/nelson/missions/` sorted by name. The most recent directory is the active mission. Set it as `{mission-dir}`. Read `{mission-dir}/quarterdeck-report.md` to establish last known state.
+1. List `.nelson/missions/` sorted by name. The most recent directory is the active mission. Set it as `{mission-dir}`. Read `{mission-dir}/quarterdeck-report.md` to establish last known state.
 2. List all tasks and their statuses: `pending`, `in_progress`, `completed`.
 3. For each `in_progress` task, verify partial outputs against the task deliverable.
 4. Discard any unverified or incomplete outputs that cannot be confirmed correct.


### PR DESCRIPTION
## Summary

- Moves Nelson mission artifact storage from `.claude/nelson/missions/` to `.nelson/missions/` at project root
- Adds `.nelson/` to `.gitignore` to exclude runtime artifacts from version control
- Updates all 6 files that reference the mission artifact path (SKILL.md, session-hygiene.md, session-resumption.md, CLAUDE.md, README.md, .gitignore)

Closes #45

## Context

The `.claude/` directory is protected in Claude Code — even `--dangerously-skip-permissions` mode prompts for confirmation when writing to it. This blocked autonomous runs. Additionally, `.claude/` is often version-controlled for sharing skills and MCP configs, but mission artifacts are ephemeral runtime data that shouldn't be committed.

The new `.nelson/` directory at project root:
1. Avoids permission prompts entirely
2. Cleanly separates runtime artifacts from configuration
3. Is gitignored by default

## Test plan

- [ ] Run `/nelson` and verify mission directory is created at `.nelson/missions/{timestamp}/`
- [ ] Verify quarterdeck reports, captain's logs, and damage reports write to the new path
- [ ] Verify no permission prompts appear when writing artifacts
- [ ] Confirm `--dangerously-skip-permissions` mode works without interruption
- [ ] Grep for `.claude/nelson/missions/` in source files — should return zero matches