### PR TITLE
fix: cross-reference rotation procedure in hull-integrity.md

### DIFF
--- a/skills/nelson/references/damage-control/hull-integrity.md
+++ b/skills/nelson/references/damage-control/hull-integrity.md
@@ -54,7 +54,7 @@ The admiral must monitor its own hull integrity with the same discipline applied
 
 1. Admiral tracks its own token usage and calculates hull integrity at each checkpoint.
 2. At Amber, admiral begins preparing a session resumption handoff using `references/damage-control/session-resumption.md`.
-3. At Red, admiral writes a full quarterdeck report (following the rotation procedure in SKILL.md Step 4) and session state to disk, then signals the Admiralty (human) that a session resumption will be needed.
+3. At Red, admiral writes a full quarterdeck report (following the rename-before-write procedure in SKILL.md Step 4 — "Write the quarterdeck report to disk") and session state to disk, then signals the Admiralty (human) that a session resumption will be needed.
 4. The admiral does not wait for Critical. An admiral at Critical risks losing coordination state that cannot be recovered.
 
 ## Relationship to Other Damage Control Procedures


### PR DESCRIPTION
## Summary

- Adds a cross-reference to the SKILL.md Step 4 rotation procedure in the Flagship Self-Monitoring section of `hull-integrity.md`
- Without this, an admiral following the Red hull status instruction literally could overwrite `quarterdeck-report.md` without rotating, losing the previous report

## Change

In `skills/nelson/references/damage-control/hull-integrity.md` line 57, the emergency quarterdeck write instruction now reads:

> At Red, admiral writes a full quarterdeck report **(following the rotation procedure in SKILL.md Step 4)** and session state to disk, then signals the Admiralty (human) that a session resumption will be needed.

Closes #42

## Test plan

- [ ] Verify the cross-reference text is present in `hull-integrity.md` line 57
- [ ] Confirm SKILL.md Step 4 contains the rotation procedure being referenced
- [ ] Install plugin and verify documentation renders correctly