### PR TITLE
fix: address low-hanging-fruit issues #55 and #47

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -139,6 +139,8 @@ Do not spawn any agents or create any tasks until the user approves. If the user
 
 If the task is complete and no pending task depends on it, send `shutdown_request` immediately — in the same response. Do not wait for the next checkpoint cadence. Check the current `TaskList` state at the moment the idle notification arrives; each notification is evaluated independently against current state. This applies even when other ships are still running and even when a captain's results were delivered inline (not as a separate artifact). The `paid-off.md` standing order governs this; consult it if uncertain.
 
+**Shutdown attempt ceiling:** If a `shutdown_request` to a ship goes unacknowledged, do not loop indefinitely. After 3 failed attempts to the same agent, abandon the shutdown attempt, note the failure in the captain's log, and continue the mission. If `TeamDelete` is blocked by stuck agents, manual cleanup is available — see `references/damage-control/man-overboard.md` for the procedure.
+
 - Keep admiral focused on coordination and unblock actions.
 - The admiral sets the mood of the squadron. Acknowledge progress, recognise strong work, and maintain cheerfulness under pressure.
 - **Checkpoint Cadence Gate:** You MUST NOT process a third task completion without writing a quarterdeck checkpoint. Before dispatching new work or processing the next completion, confirm the last checkpoint is no more than 2 completions old. The quarterdeck report is your only recovery point if context compaction occurs — stale reports mean lost coordination state.

--- a/skills/nelson/references/admiralty-templates/crew-briefing.md
+++ b/skills/nelson/references/admiralty-templates/crew-briefing.md
@@ -45,6 +45,9 @@ Standing Orders:
   before acting.
 - If you reach a step requiring human action (admiralty-action-required: yes), invoke
   the awaiting-admiralty standing order: references/standing-orders/awaiting-admiralty.md
+- Shutdown protocol: if you receive `{"type": "shutdown_request"}`, respond immediately
+  with `{"type": "shutdown_response"}` and cease all activity. Do NOT respond with an
+  idle notification or any other message type.
 Marine Deployment Brief: use the full template at
   references/admiralty-templates/marine-deployment-brief.md — it includes model
   assignment guidance and haiku briefing requirements.

--- a/skills/nelson/references/damage-control/hull-integrity.md
+++ b/skills/nelson/references/damage-control/hull-integrity.md
@@ -20,7 +20,7 @@ The admiral maintains a readiness board to track hull integrity across all ships
 1. At each quarterdeck checkpoint, collect the latest damage report from every active ship.
 2. List each ship with its hull integrity status, percentage, and whether relief is requested.
 3. Flag any ship at Red or Critical for immediate attention.
-4. Record the board in the quarterdeck report under the budget section.
+4. Record the board in the quarterdeck report under the "Hull integrity (squadron readiness board):" section.
 
 The readiness board gives the admiral a single view of squadron endurance and drives decisions about task reassignment, descoping, and relief.
 

--- a/skills/nelson/references/damage-control/man-overboard.md
+++ b/skills/nelson/references/damage-control/man-overboard.md
@@ -22,3 +22,15 @@ Use when a crew member aboard a ship is stuck, looping, or unresponsive. The cap
 6. Replacement crew member resumes from the last verified checkpoint, not from scratch.
 7. Captain updates the ship manifest to reflect the new assignment.
 8. If the same role fails twice, captain escalates to admiral with a summary and recommendation.
+
+## Manual Cleanup Fallback
+
+Use when the shutdown attempt ceiling is exhausted (3 failed attempts) and `TeamDelete` is blocked by stuck agents that will not respond to shutdown requests. This is a last resort — always attempt graceful shutdown first.
+
+1. Admiral confirms that 3 shutdown attempts have failed and `TeamDelete` is blocked.
+2. Admiral runs the following commands to remove the stuck team manually:
+   - `rm -rf ~/.claude/teams/{team-name}` — removes the team registration
+   - `rm -rf ~/.claude/tasks/{team-name}` — removes associated task data
+3. Admiral verifies the team no longer appears in active team listings.
+4. Admiral records the affected agents and the manual cleanup action in the captain's log.
+5. Admiral spawns a fresh replacement team and re-issues the affected tasks from the last verified checkpoint.


### PR DESCRIPTION
## Summary

- **Fix #55**: `hull-integrity.md` stale cross-reference now points to the dedicated "Hull integrity (squadron readiness board):" section in the quarterdeck report template, not the budget section
- **Fix #47 (3 mitigations)**: Harden shutdown protocol for haiku agents that fail to respond to `shutdown_request`:
  1. Shutdown attempt ceiling (max 3) in SKILL.md quarterdeck rhythm
  2. Shutdown protocol standing order in crew briefing template
  3. Manual cleanup fallback section in man-overboard.md

Closes #55
Closes #47

### Issue #32 (assets/ vs references/)

Reviewed against [Anthropic's official skill authoring best practices](https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills/best-practices). The guidance:
- Does not define an `assets/` convention
- Uses `reference/` as a directory name in its own examples (Pattern 2: Domain-specific organization)
- Cares about descriptive naming and domain-based organization, which `references/` already satisfies

Recommend closing #32 as won't-fix — Nelson's `references/` directory aligns with official guidance.

## Test plan

- [ ] Verify hull-integrity.md line 23 matches the quarterdeck-report.md template section name
- [ ] Verify SKILL.md shutdown ceiling rule is positioned after the idle notification rule
- [ ] Verify crew-briefing.md shutdown protocol is inside the `== CREW BRIEFING ==` block
- [ ] Verify man-overboard.md Manual Cleanup Fallback section follows Crew Variant section
- [ ] Run `bash skills/nelson/scripts/check-references.sh` to validate cross-references