### PR TITLE
feat: formation consolidation + headless mission mode

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -115,9 +115,22 @@ Actions marked `timing: before task starts` require your sign-off before the rel
 
 Do not spawn any agents or create any tasks until the user approves. If the user requests changes, revise and redisplay before proceeding.
 
-> **Note:** Nelson requires an interactive session for formation approval. Headless and CI invocation are not supported at this time.
+> **Note:** For headless and CI invocation, use `nelson-data.py headless --auto-approve` which combines Steps 1-3 and skips the interactive approval gate. See `references/structured-data.md` for details.
 
-**Structured Data Capture:** Once formation is approved, run these commands in order:
+**Structured Data Capture:** Once formation is approved, use the composite `form` command (recommended) or the individual commands below.
+
+**Recommended — composite `form` command:** Write a plan JSON file with the task and squadron definitions, then run a single command:
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py form \
+  --mission-dir {mission-dir} \
+  --plan {mission-dir}/plan-input.json \
+  --mode [mode]
+```
+
+This registers all tasks, records the squadron, computes DAG metrics, and runs the conflict scan in one step. See `references/structured-data.md` for the plan JSON schema and output format.
+
+**Alternative — individual commands:**
 1. `python3 .claude/skills/nelson/scripts/nelson-data.py task --mission-dir {mission-dir} --id N --name "..." --owner "..." ...` for each task (owners are now known from formation). See `references/structured-data.md` for task arguments.
 2. `python3 .claude/skills/nelson/scripts/nelson-data.py plan-approved --mission-dir {mission-dir}` to finalise the battle plan and compute DAG metrics.
 3. `python3 .claude/skills/nelson/scripts/nelson-data.py squadron --mission-dir {mission-dir} --admiral "..." --admiral-model [model] --captain "name:class:model:task_id" ... --mode [mode]` to record squadron composition. Repeat `--captain` for each captain. See `references/structured-data.md` for the full argument list.

--- a/skills/nelson/references/structured-data.md
+++ b/skills/nelson/references/structured-data.md
@@ -109,6 +109,84 @@ python3 .claude/skills/nelson/scripts/nelson-data.py stand-down \
   --metric-result "47/47 auth tests pass, 0 new dependencies"
 ```
 
+### `form` — Composite formation (recommended)
+
+Run at Step 3 instead of individual `task`, `squadron`, and `plan-approved` calls. Consolidates the entire formation phase into a single command.
+
+Reads a plan JSON file containing tasks and squadron definitions. Registers all tasks, records the squadron, computes DAG metrics, and runs the conflict scan. Outputs a structured JSON summary to stdout; progress messages go to stderr.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py form \
+  --mission-dir .nelson/missions/2026-03-27_120000_a1b2c3d4 \
+  --plan battle-plan-input.json \
+  --mode subagents
+```
+
+The plan JSON file must contain `squadron` and `tasks` keys:
+
+```json
+{
+  "squadron": {
+    "admiral": { "ship_name": "HMS Victory", "model": "opus" },
+    "captains": [
+      { "ship_name": "HMS Argyll", "ship_class": "frigate", "model": "sonnet", "task_id": 1 }
+    ],
+    "red_cell": { "ship_name": "HMS Astute", "model": "haiku" }
+  },
+  "tasks": [
+    {
+      "id": 1,
+      "name": "Auth module refactor",
+      "owner": "HMS Argyll",
+      "deliverable": "Refactored auth module with JWT support",
+      "dependencies": [],
+      "station_tier": 1,
+      "file_ownership": ["src/auth/**"]
+    }
+  ]
+}
+```
+
+Output summary (stdout):
+
+```json
+{
+  "status": "ok",
+  "mission_dir": ".nelson/missions/2026-03-27_120000_a1b2c3d4",
+  "tasks_registered": 1,
+  "squadron": { "admiral": "HMS Victory", "captains": 1, "mode": "subagents", "has_red_cell": true },
+  "dag_metrics": { "parallel_tracks": 1, "critical_path_length": 1 },
+  "conflict_scan": { "clean": true, "exit_code": 0, "stdout": "..." }
+}
+```
+
+### `headless` — Headless mission (init + form)
+
+Run to create a mission and complete formation in a single command. Reads sailing orders and battle plan from JSON files. Designed for CI/CD pipeline integration.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py headless \
+  --sailing-orders sailing-orders.json \
+  --battle-plan battle-plan.json \
+  --mode subagents \
+  --auto-approve
+```
+
+The sailing orders JSON uses the same fields as `sailing-orders.json`:
+
+```json
+{
+  "outcome": "Refactor auth module to use JWT tokens",
+  "metric": "All 47 auth tests pass, no new dependencies",
+  "deadline": "this_session",
+  "budget": { "token_limit": 200000 },
+  "constraints": ["Do not modify the public API surface"],
+  "out_of_scope": ["Migration script for existing sessions"]
+}
+```
+
+Outputs a combined JSON summary to stdout containing `mission_dir`, `sailing_orders`, and `formation` sections.
+
 ### `status` — Print current fleet status (read-only)
 
 Run at any time for a quick status check. Useful for session resumption and hooks.
@@ -126,7 +204,8 @@ python3 .claude/skills/nelson/scripts/nelson-data.py status \
 |---|---|---|---|
 | Step 1: Sailing Orders | `init` | `sailing-orders.json`, `mission-log.json` | (conversation-only) |
 | Step 2: Battle Plan | (none — owners not yet assigned) | — | (conversation-only) |
-| Step 3: Form Squadron | `task` (per task), then `plan-approved`, then `squadron` | `battle-plan.json`, `mission-log.json`, `fleet-status.json` | (conversation-only) |
+| Step 3: Form Squadron | `form` (recommended), or individual `task` + `plan-approved` + `squadron` | `battle-plan.json`, `mission-log.json`, `fleet-status.json` | (conversation-only) |
+| Step 1-3: Headless | `headless` (CI/CD) | all of the above in one step | — |
 | Step 4: Get Permission to Sail | (none) | — | (conversation-only) |
 | Step 5: Each Checkpoint | `checkpoint` | `mission-log.json`, `fleet-status.json` | `quarterdeck-report.md` |
 | Step 5: Between Checkpoints | `event` | `mission-log.json` | -- |

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -29,6 +29,7 @@ import argparse
 import json
 import os
 import stat
+import subprocess
 import sys
 import tempfile
 
@@ -406,41 +407,58 @@ def _build_mission_record(mission_dir: Path) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-def cmd_init(args: argparse.Namespace) -> None:
-    """Create mission directory and write sailing-orders.json."""
+def _do_init(
+    outcome: str,
+    metric: str,
+    deadline: str,
+    token_budget: int | None = None,
+    time_limit: int | None = None,
+    constraints: list[str] | None = None,
+    out_of_scope: list[str] | None = None,
+    stop_criteria: list[str] | None = None,
+    handoff_artifacts: list[str] | None = None,
+) -> Path:
+    """Create mission directory and write initial JSON files.  Returns the path."""
     base = Path(".nelson") / "missions" / _mission_dir_stamp()
     base.mkdir(parents=True, exist_ok=True)
     (base / "damage-reports").mkdir(exist_ok=True)
     (base / "turnover-briefs").mkdir(exist_ok=True)
 
-    budget: dict[str, Any] = {}
-    if args.token_budget is not None:
-        budget["token_limit"] = args.token_budget
-    else:
-        budget["token_limit"] = None
-    if args.time_limit is not None:
-        budget["time_limit_minutes"] = args.time_limit
-    else:
-        budget["time_limit_minutes"] = None
-
     sailing_orders = {
         "version": 1,
-        "outcome": args.outcome,
-        "success_metric": args.metric,
-        "deadline": args.deadline,
-        "budget": budget,
-        "constraints": list(args.constraints or []),
-        "out_of_scope": list(args.out_of_scope or []),
-        "stop_criteria": list(args.stop_criteria or []),
-        "handoff_artifacts": list(args.handoff_artifacts or []),
+        "outcome": outcome,
+        "success_metric": metric,
+        "deadline": deadline,
+        "budget": {
+            "token_limit": token_budget,
+            "time_limit_minutes": time_limit,
+        },
+        "constraints": list(constraints or []),
+        "out_of_scope": list(out_of_scope or []),
+        "stop_criteria": list(stop_criteria or []),
+        "handoff_artifacts": list(handoff_artifacts or []),
         "created_at": _now_iso(),
     }
 
-    mission_log = {"version": 1, "events": []}
-
     _write_json(base / "sailing-orders.json", sailing_orders)
-    _write_json(base / "mission-log.json", mission_log)
+    _write_json(base / "mission-log.json", {"version": 1, "events": []})
 
+    return base
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    """Create mission directory and write sailing-orders.json."""
+    base = _do_init(
+        outcome=args.outcome,
+        metric=args.metric,
+        deadline=args.deadline,
+        token_budget=args.token_budget,
+        time_limit=args.time_limit,
+        constraints=args.constraints,
+        out_of_scope=args.out_of_scope,
+        stop_criteria=args.stop_criteria,
+        handoff_artifacts=args.handoff_artifacts,
+    )
     # Print the mission directory path (consumed by admiral)
     print(str(base))
 
@@ -450,47 +468,26 @@ def cmd_init(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
-def cmd_squadron(args: argparse.Namespace) -> None:
-    """Record squadron formation in battle-plan.json and mission-log.json."""
-    mission_dir = _require_mission_dir(args)
-
-    # Parse captain specs: "name:class:model:task_id"
-    captains: list[dict[str, Any]] = []
-    for spec in args.captain or []:
-        parts = spec.split(":")
-        if len(parts) != 4:
-            _die(f"Error: captain spec must be 'name:class:model:task_id', got: {spec}")
-        ship_name, ship_class, model, task_id_str = parts
-        try:
-            task_id = int(task_id_str)
-        except ValueError:
-            _die(f"Error: task_id must be an integer, got: {task_id_str}")
-            return  # unreachable but helps type checkers
-        captains.append(
-            {
-                "ship_name": ship_name,
-                "ship_class": ship_class,
-                "model": model,
-                "task_id": task_id,
-            }
-        )
-
+def _register_squadron(
+    mission_dir: Path,
+    admiral: str,
+    admiral_model: str,
+    captains: list[dict[str, Any]],
+    mode: str = "subagents",
+    red_cell: str | None = None,
+    red_cell_model: str | None = None,
+) -> None:
+    """Write squadron to battle-plan.json, fleet-status.json, and mission-log."""
     squadron: dict[str, Any] = {
-        "admiral": {
-            "ship_name": args.admiral,
-            "model": args.admiral_model,
-        },
-        "captains": captains,
+        "admiral": {"ship_name": admiral, "model": admiral_model},
+        "captains": list(captains),
     }
 
-    if args.red_cell:
+    if red_cell:
         squadron["red_cell"] = {
-            "ship_name": args.red_cell,
-            "model": args.red_cell_model or "haiku",
+            "ship_name": red_cell,
+            "model": red_cell_model or "haiku",
         }
-
-    if args.mode and args.mode not in VALID_MODES:
-        _die(f"Error: --mode must be one of {sorted(VALID_MODES)}")
 
     # Build/update battle-plan.json
     bp_path = mission_dir / "battle-plan.json"
@@ -509,31 +506,30 @@ def cmd_squadron(args: argparse.Namespace) -> None:
         "timestamp": _now_iso(),
         "data": {
             "captain_count": len(captains),
-            "has_red_cell": args.red_cell is not None,
-            "execution_mode": args.mode or "subagents",
+            "has_red_cell": red_cell is not None,
+            "execution_mode": mode,
             "standing_order_check": {"triggered": [], "remedies": []},
         },
     }
     _append_event(mission_dir, event)
 
     # Write initial fleet-status.json
-    squadron_list: list[dict[str, Any]] = []
-    for cap in captains:
-        squadron_list.append(
-            {
-                "ship_name": cap["ship_name"],
-                "ship_class": cap["ship_class"],
-                "role": "captain",
-                "hull_integrity_pct": 100,
-                "hull_integrity_status": "Green",
-                "relief_requested": False,
-                "task_id": cap["task_id"],
-                "task_name": None,
-                "task_status": "pending",
-            }
-        )
+    squadron_list: list[dict[str, Any]] = [
+        {
+            "ship_name": cap["ship_name"],
+            "ship_class": cap["ship_class"],
+            "role": "captain",
+            "hull_integrity_pct": 100,
+            "hull_integrity_status": "Green",
+            "relief_requested": False,
+            "task_id": cap["task_id"],
+            "task_name": None,
+            "task_status": "pending",
+        }
+        for cap in captains
+    ]
 
-    fleet_status = {
+    fleet_status: dict[str, Any] = {
         "version": 1,
         "mission": {
             "outcome": None,
@@ -574,6 +570,49 @@ def cmd_squadron(args: argparse.Namespace) -> None:
 
     _write_json(mission_dir / "fleet-status.json", fleet_status)
 
+
+def _parse_captain_specs(specs: list[str]) -> list[dict[str, Any]]:
+    """Parse colon-delimited captain specs into dicts."""
+    captains: list[dict[str, Any]] = []
+    for spec in specs:
+        parts = spec.split(":")
+        if len(parts) != 4:
+            _die(f"Error: captain spec must be 'name:class:model:task_id', got: {spec}")
+        ship_name, ship_class, model, task_id_str = parts
+        try:
+            task_id = int(task_id_str)
+        except ValueError:
+            _die(f"Error: task_id must be an integer, got: {task_id_str}")
+            return []  # unreachable but helps type checkers
+        captains.append(
+            {
+                "ship_name": ship_name,
+                "ship_class": ship_class,
+                "model": model,
+                "task_id": task_id,
+            }
+        )
+    return captains
+
+
+def cmd_squadron(args: argparse.Namespace) -> None:
+    """Record squadron formation in battle-plan.json and mission-log.json."""
+    mission_dir = _require_mission_dir(args)
+    captains = _parse_captain_specs(args.captain or [])
+
+    if args.mode and args.mode not in VALID_MODES:
+        _die(f"Error: --mode must be one of {sorted(VALID_MODES)}")
+
+    _register_squadron(
+        mission_dir=mission_dir,
+        admiral=args.admiral,
+        admiral_model=args.admiral_model,
+        captains=captains,
+        mode=args.mode or "subagents",
+        red_cell=args.red_cell,
+        red_cell_model=args.red_cell_model,
+    )
+
     print(
         f"[nelson-data] Squadron formed: admiral {args.admiral}, "
         f"{len(captains)} captains"
@@ -584,6 +623,50 @@ def cmd_squadron(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 # Subcommand: task
 # ---------------------------------------------------------------------------
+
+
+def _build_task_record(
+    task_id: int,
+    name: str,
+    owner: str,
+    deliverable: str,
+    deps: list[int],
+    station_tier: int,
+    files: list[str],
+    validation: str | None = None,
+    rollback_note: bool = False,
+    admiralty_action: bool = False,
+) -> dict[str, Any]:
+    """Build a task dict from typed parameters."""
+    return {
+        "id": task_id,
+        "name": name,
+        "owner": owner,
+        "deliverable": deliverable,
+        "dependencies": list(deps),
+        "dependents": [],
+        "station_tier": station_tier,
+        "file_ownership": list(files),
+        "validation_required": validation or None,
+        "rollback_note_required": rollback_note,
+        "admiralty_action_required": admiralty_action,
+    }
+
+
+def _register_tasks(mission_dir: Path, tasks: list[dict[str, Any]]) -> None:
+    """Write a list of tasks to battle-plan.json (bulk registration)."""
+    bp_path = mission_dir / "battle-plan.json"
+    if bp_path.exists():
+        battle_plan = _read_json(bp_path)
+    else:
+        battle_plan = {"version": 1}
+
+    existing_tasks = list(battle_plan.get("tasks", []))
+    all_tasks = existing_tasks + list(tasks)
+    all_tasks = _recompute_dependents(all_tasks)
+
+    new_battle_plan = {**battle_plan, "tasks": all_tasks}
+    _write_json(bp_path, new_battle_plan)
 
 
 def cmd_task(args: argparse.Namespace) -> None:
@@ -604,34 +687,20 @@ def cmd_task(args: argparse.Namespace) -> None:
     if args.files:
         files = [f.strip() for f in args.files.split(",") if f.strip()]
 
-    task: dict[str, Any] = {
-        "id": args.id,
-        "name": args.name,
-        "owner": args.owner,
-        "deliverable": args.deliverable,
-        "dependencies": deps,
-        "dependents": [],
-        "station_tier": args.station_tier,
-        "file_ownership": files,
-        "validation_required": args.validation or None,
-        "rollback_note_required": bool(args.rollback_note),
-        "admiralty_action_required": bool(args.admiralty_action),
-    }
+    task = _build_task_record(
+        task_id=args.id,
+        name=args.name,
+        owner=args.owner,
+        deliverable=args.deliverable,
+        deps=deps,
+        station_tier=args.station_tier,
+        files=files,
+        validation=args.validation,
+        rollback_note=bool(args.rollback_note),
+        admiralty_action=bool(args.admiralty_action),
+    )
 
-    bp_path = mission_dir / "battle-plan.json"
-    if bp_path.exists():
-        battle_plan = _read_json(bp_path)
-    else:
-        battle_plan = {"version": 1}
-
-    existing_tasks = list(battle_plan.get("tasks", []))
-    new_tasks = existing_tasks + [task]
-
-    # Recompute dependents for all tasks
-    new_tasks = _recompute_dependents(new_tasks)
-
-    new_battle_plan = {**battle_plan, "tasks": new_tasks}
-    _write_json(bp_path, new_battle_plan)
+    _register_tasks(mission_dir, [task])
 
     print(f"[nelson-data] Task {args.id} added: {args.name} -> {args.owner}")
 
@@ -654,10 +723,12 @@ def _recompute_dependents(tasks: list[dict]) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def cmd_plan_approved(args: argparse.Namespace) -> None:
-    """Finalize the battle plan — compute DAG metrics and log event."""
-    mission_dir = _require_mission_dir(args)
+def _finalize_plan(mission_dir: Path) -> dict[str, Any]:
+    """Finalize battle plan: compute DAG metrics, log event, update fleet status.
 
+    Returns a dict with ``task_count``, ``parallel_tracks``, and
+    ``critical_path_length``.
+    """
     bp_path = mission_dir / "battle-plan.json"
     if not bp_path.exists():
         _die("Error: battle-plan.json does not exist. Run 'squadron' and 'task' first.")
@@ -668,17 +739,11 @@ def cmd_plan_approved(args: argparse.Namespace) -> None:
     if not tasks:
         _die("Error: no tasks in battle-plan.json. Run 'task' to add tasks first.")
 
-    # Compute parallel_tracks and critical_path_length from dependency graph
     parallel_tracks, critical_path_length = _compute_dag_metrics(tasks)
 
-    # Stamp the battle plan as approved
-    new_battle_plan = {
-        **battle_plan,
-        "amended_at": None,
-    }
+    new_battle_plan = {**battle_plan, "amended_at": None}
     _write_json(bp_path, new_battle_plan)
 
-    # Append battle_plan_approved event
     event = {
         "type": "battle_plan_approved",
         "checkpoint": 0,
@@ -687,15 +752,11 @@ def cmd_plan_approved(args: argparse.Namespace) -> None:
             "task_count": len(tasks),
             "parallel_tracks": parallel_tracks,
             "critical_path_length": critical_path_length,
-            "standing_order_check": {
-                "triggered": [],
-                "remedies": [],
-            },
+            "standing_order_check": {"triggered": [], "remedies": []},
         },
     }
     _append_event(mission_dir, event)
 
-    # Update fleet-status.json
     fs_path = mission_dir / "fleet-status.json"
     if fs_path.exists():
         fleet_status = _read_json(fs_path)
@@ -717,10 +778,22 @@ def cmd_plan_approved(args: argparse.Namespace) -> None:
     }
     _write_json(fs_path, new_fleet_status)
 
+    return {
+        "task_count": len(tasks),
+        "parallel_tracks": parallel_tracks,
+        "critical_path_length": critical_path_length,
+    }
+
+
+def cmd_plan_approved(args: argparse.Namespace) -> None:
+    """Finalize the battle plan — compute DAG metrics and log event."""
+    mission_dir = _require_mission_dir(args)
+    metrics = _finalize_plan(mission_dir)
+
     print(
-        f"[nelson-data] Battle plan approved: {len(tasks)} tasks, "
-        f"{parallel_tracks} parallel tracks, "
-        f"critical path length {critical_path_length}"
+        f"[nelson-data] Battle plan approved: {metrics['task_count']} tasks, "
+        f"{metrics['parallel_tracks']} parallel tracks, "
+        f"critical path length {metrics['critical_path_length']}"
     )
 
 
@@ -1124,6 +1197,185 @@ def cmd_stand_down(args: argparse.Namespace) -> None:
         f"Tasks: {tasks_completed}/{len(tasks)} | "
         f"Violations: {violation_count}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: form (composite formation)
+# ---------------------------------------------------------------------------
+
+_CONFLICT_SCAN_SCRIPT = Path(__file__).resolve().parent / "nelson_conflict_scan.py"
+
+
+def _validate_plan_json(plan: dict) -> None:
+    """Validate plan JSON structure.  Calls _die on failure."""
+    if "squadron" not in plan:
+        _die("Error: plan JSON must contain a 'squadron' key.")
+    sq = plan["squadron"]
+    if "admiral" not in sq or "captains" not in sq:
+        _die("Error: squadron must contain 'admiral' and 'captains'.")
+    if not sq["captains"]:
+        _die("Error: squadron must have at least one captain.")
+    tasks = plan.get("tasks", [])
+    if not tasks:
+        _die("Error: plan JSON must contain a non-empty 'tasks' array.")
+    required_task_fields = {"id", "name", "owner", "deliverable", "station_tier"}
+    for i, task in enumerate(tasks):
+        missing = required_task_fields - set(task.keys())
+        if missing:
+            _die(f"Error: task {i} is missing required fields: {sorted(missing)}")
+
+
+def _run_conflict_scan(battle_plan_path: Path) -> dict[str, Any]:
+    """Run nelson_conflict_scan.py and return structured result."""
+    if not _CONFLICT_SCAN_SCRIPT.exists():
+        return {"clean": True, "skipped": True, "stdout": "conflict scan script not found"}
+    result = subprocess.run(
+        [sys.executable, str(_CONFLICT_SCAN_SCRIPT), "--plan", str(battle_plan_path)],
+        capture_output=True,
+        text=True,
+    )
+    has_warning = "[!] WARNING" in result.stdout
+    return {
+        "clean": not has_warning,
+        "exit_code": result.returncode,
+        "stdout": result.stdout.strip(),
+    }
+
+
+def _do_form(
+    mission_dir: Path,
+    plan: dict,
+    mode: str = "subagents",
+) -> dict[str, Any]:
+    """Execute the full formation sequence.  Returns a summary dict."""
+    tasks = plan["tasks"]
+    sq = plan["squadron"]
+    mode = plan.get("mode", mode)
+
+    # Build task records from plan
+    task_records = [
+        _build_task_record(
+            task_id=t["id"],
+            name=t["name"],
+            owner=t["owner"],
+            deliverable=t["deliverable"],
+            deps=list(t.get("dependencies", [])),
+            station_tier=t["station_tier"],
+            files=list(t.get("file_ownership", [])),
+            validation=t.get("validation_required"),
+            rollback_note=bool(t.get("rollback_note_required", False)),
+            admiralty_action=bool(t.get("admiralty_action_required", False)),
+        )
+        for t in tasks
+    ]
+
+    _err(f"[nelson-data] Registering {len(task_records)} tasks...")
+    _register_tasks(mission_dir, task_records)
+
+    admiral = sq["admiral"]
+    captains = sq["captains"]
+    red_cell = sq.get("red_cell")
+
+    _err(f"[nelson-data] Forming squadron: {admiral['ship_name']}, {len(captains)} captains...")
+    _register_squadron(
+        mission_dir=mission_dir,
+        admiral=admiral["ship_name"],
+        admiral_model=admiral["model"],
+        captains=captains,
+        mode=mode,
+        red_cell=red_cell["ship_name"] if red_cell else None,
+        red_cell_model=red_cell.get("model") if red_cell else None,
+    )
+
+    _err("[nelson-data] Finalizing battle plan...")
+    metrics = _finalize_plan(mission_dir)
+
+    _err("[nelson-data] Running conflict scan...")
+    scan_result = _run_conflict_scan(mission_dir / "battle-plan.json")
+
+    return {
+        "status": "ok",
+        "mission_dir": str(mission_dir),
+        "tasks_registered": len(task_records),
+        "squadron": {
+            "admiral": admiral["ship_name"],
+            "captains": len(captains),
+            "mode": mode,
+            "has_red_cell": red_cell is not None,
+        },
+        "dag_metrics": {
+            "parallel_tracks": metrics["parallel_tracks"],
+            "critical_path_length": metrics["critical_path_length"],
+        },
+        "conflict_scan": scan_result,
+    }
+
+
+def cmd_form(args: argparse.Namespace) -> None:
+    """Composite formation: register tasks, squadron, finalize plan, scan conflicts."""
+    mission_dir = _require_mission_dir(args)
+
+    plan_path = Path(args.plan)
+    if not plan_path.exists():
+        _die(f"Error: plan file does not exist: {plan_path}")
+
+    plan = _read_json(plan_path)
+    _validate_plan_json(plan)
+
+    summary = _do_form(mission_dir, plan, mode=args.mode or "subagents")
+
+    # Structured JSON summary to stdout
+    print(json.dumps(summary, indent=JSON_INDENT))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: headless (init + form)
+# ---------------------------------------------------------------------------
+
+
+def cmd_headless(args: argparse.Namespace) -> None:
+    """Headless mission: create mission directory and run full formation."""
+    so_path = Path(args.sailing_orders)
+    if not so_path.exists():
+        _die(f"Error: sailing orders file does not exist: {so_path}")
+
+    bp_path = Path(args.battle_plan)
+    if not bp_path.exists():
+        _die(f"Error: battle plan file does not exist: {bp_path}")
+
+    so_data = _read_json(so_path)
+    plan_data = _read_json(bp_path)
+    _validate_plan_json(plan_data)
+
+    # Create mission directory
+    mission_dir = _do_init(
+        outcome=so_data.get("outcome", ""),
+        metric=so_data.get("metric", so_data.get("success_metric", "")),
+        deadline=so_data.get("deadline", "this_session"),
+        token_budget=so_data.get("budget", {}).get("token_limit") if isinstance(so_data.get("budget"), dict) else so_data.get("token_budget"),
+        time_limit=so_data.get("budget", {}).get("time_limit_minutes") if isinstance(so_data.get("budget"), dict) else so_data.get("time_limit"),
+        constraints=so_data.get("constraints"),
+        out_of_scope=so_data.get("out_of_scope"),
+        stop_criteria=so_data.get("stop_criteria"),
+        handoff_artifacts=so_data.get("handoff_artifacts"),
+    )
+
+    _err(f"[nelson-data] Mission directory: {mission_dir}")
+
+    formation = _do_form(mission_dir, plan_data, mode=args.mode or "subagents")
+
+    summary = {
+        "status": "ok",
+        "mission_dir": str(mission_dir),
+        "sailing_orders": {
+            "outcome": so_data.get("outcome", ""),
+            "success_metric": so_data.get("metric", so_data.get("success_metric", "")),
+            "deadline": so_data.get("deadline", "this_session"),
+        },
+        "formation": formation,
+    }
+
+    print(json.dumps(summary, indent=JSON_INDENT))
 
 
 # ---------------------------------------------------------------------------
@@ -1652,6 +1904,35 @@ def build_parser() -> argparse.ArgumentParser:
     p_sd.add_argument("--actual-outcome", default="", help="Actual outcome description")
     p_sd.add_argument("--metric-result", default="", help="Success metric result")
 
+    # --- form ---
+    p_form = subs.add_parser("form", help="Composite formation: tasks + squadron + plan")
+    p_form.add_argument("--mission-dir", required=True, help="Mission directory path")
+    p_form.add_argument("--plan", required=True, help="Path to plan JSON file")
+    p_form.add_argument(
+        "--mode",
+        default="subagents",
+        help="Execution mode: single-session, subagents, agent-team",
+    )
+
+    # --- headless ---
+    p_hl = subs.add_parser("headless", help="Headless mission: init + form in one step")
+    p_hl.add_argument(
+        "--sailing-orders", required=True, help="Path to sailing orders JSON file"
+    )
+    p_hl.add_argument(
+        "--battle-plan", required=True, help="Path to battle plan JSON file"
+    )
+    p_hl.add_argument(
+        "--mode",
+        default="subagents",
+        help="Execution mode: single-session, subagents, agent-team",
+    )
+    p_hl.add_argument(
+        "--auto-approve",
+        action="store_true",
+        help="Skip interactive approval gate",
+    )
+
     # --- status ---
     p_st = subs.add_parser("status", help="Print current fleet status")
     p_st.add_argument("--mission-dir", required=True, help="Mission directory path")
@@ -1704,6 +1985,8 @@ def main() -> None:
         "event": lambda: cmd_event(args, extra),
         "checkpoint": lambda: cmd_checkpoint(args),
         "stand-down": lambda: cmd_stand_down(args),
+        "form": lambda: cmd_form(args),
+        "headless": lambda: cmd_headless(args),
         "status": lambda: cmd_status(args),
         "index": lambda: cmd_index(args),
         "history": lambda: cmd_history(args),

--- a/skills/nelson/scripts/nelson_conflict_scan.py
+++ b/skills/nelson/scripts/nelson_conflict_scan.py
@@ -121,7 +121,7 @@ def parse_battle_plan(path: Path) -> dict:
         data = json.loads(content)
         for task in data.get("tasks", []):
             owner = task.get("owner")
-            files = task.get("files", [])
+            files = task.get("file_ownership", task.get("files", []))
             if owner and files:
                 if owner not in ownership:
                     ownership[owner] = set()

--- a/skills/nelson/scripts/test_nelson_conflict_scan.py
+++ b/skills/nelson/scripts/test_nelson_conflict_scan.py
@@ -128,6 +128,23 @@ Task ID: 2
         self.assertEqual(conflicts[0][1], "src/shared.py")
         self.assertEqual(conflicts[0][3], "src/shared.py")
 
+    def test_json_file_ownership_key(self):
+        """parse_battle_plan reads 'file_ownership' from JSON battle plans."""
+        import json
+
+        plan = {
+            "tasks": [
+                {"owner": "HMS Victory", "file_ownership": ["src/api.py", "src/models.py"]},
+                {"owner": "HMS Enterprise", "file_ownership": ["src/ui.js"]},
+            ]
+        }
+        plan_path = self.root / "battle-plan.json"
+        plan_path.write_text(json.dumps(plan))
+
+        ownership = parse_battle_plan(plan_path)
+        self.assertEqual(ownership["HMS Victory"], {"src/api.py", "src/models.py"})
+        self.assertEqual(ownership["HMS Enterprise"], {"src/ui.js"})
+
     def test_path_traversal_skipped(self):
         """Files that escape the project root should be skipped."""
         # Create a file inside the root so we have at least one valid entry

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -530,6 +530,282 @@ class TestStatus:
 
 
 # ---------------------------------------------------------------------------
+# Form (composite command)
+# ---------------------------------------------------------------------------
+
+
+def write_plan_json(path: Path, plan: dict) -> None:
+    """Write a plan JSON file for the form command."""
+    path.write_text(json.dumps(plan), encoding="utf-8")
+
+
+def make_plan(
+    captains: list[dict] | None = None,
+    tasks: list[dict] | None = None,
+    admiral: dict | None = None,
+    mode: str = "subagents",
+    red_cell: dict | None = None,
+) -> dict:
+    """Build a plan dict suitable for the form command."""
+    default_captains = [
+        {"ship_name": "HMS Argyll", "ship_class": "frigate", "model": "sonnet", "task_id": 1},
+    ] if captains is None else captains
+    default_tasks = [
+        {
+            "id": 1,
+            "name": "Auth refactor",
+            "owner": "HMS Argyll",
+            "deliverable": "JWT-based auth module",
+            "dependencies": [],
+            "station_tier": 0,
+            "file_ownership": [],
+        },
+    ] if tasks is None else tasks
+    squadron: dict = {
+        "admiral": admiral or {"ship_name": "HMS Victory", "model": "opus"},
+        "captains": default_captains,
+    }
+    if red_cell:
+        squadron["red_cell"] = red_cell
+    return {"squadron": squadron, "tasks": default_tasks, "mode": mode}
+
+
+class TestForm:
+    def test_form_registers_tasks(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan()
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        bp = read_json(mission_dir / "battle-plan.json")
+        assert len(bp["tasks"]) == 1
+        assert bp["tasks"][0]["name"] == "Auth refactor"
+        assert bp["tasks"][0]["owner"] == "HMS Argyll"
+
+    def test_form_records_squadron(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan()
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        bp = read_json(mission_dir / "battle-plan.json")
+        assert bp["squadron"]["admiral"]["ship_name"] == "HMS Victory"
+        assert len(bp["squadron"]["captains"]) == 1
+        fs = read_json(mission_dir / "fleet-status.json")
+        assert fs["mission"]["status"] == "underway"
+
+    def test_form_computes_dag_metrics(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan(
+            captains=[
+                {"ship_name": "HMS Argyll", "ship_class": "frigate", "model": "sonnet", "task_id": 1},
+                {"ship_name": "HMS Kent", "ship_class": "destroyer", "model": "sonnet", "task_id": 2},
+                {"ship_name": "HMS Lancaster", "ship_class": "frigate", "model": "sonnet", "task_id": 3},
+            ],
+            tasks=[
+                {"id": 1, "name": "A", "owner": "HMS Argyll", "deliverable": "D1",
+                 "dependencies": [], "station_tier": 0, "file_ownership": []},
+                {"id": 2, "name": "B", "owner": "HMS Kent", "deliverable": "D2",
+                 "dependencies": [], "station_tier": 0, "file_ownership": []},
+                {"id": 3, "name": "C", "owner": "HMS Lancaster", "deliverable": "D3",
+                 "dependencies": [1], "station_tier": 1, "file_ownership": []},
+            ],
+        )
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        result = run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        summary = json.loads(result.stdout)
+        assert summary["dag_metrics"]["parallel_tracks"] == 2
+        assert summary["dag_metrics"]["critical_path_length"] == 2
+
+    def test_form_outputs_json_summary(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan()
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        result = run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        summary = json.loads(result.stdout)
+        assert summary["status"] == "ok"
+        assert summary["tasks_registered"] == 1
+        assert summary["squadron"]["admiral"] == "HMS Victory"
+        assert summary["squadron"]["captains"] == 1
+        assert summary["squadron"]["mode"] == "subagents"
+        assert "conflict_scan" in summary
+
+    def test_form_missing_plan_fails(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        run(
+            "form", "--mission-dir", str(mission_dir),
+            "--plan", str(tmp_path / "nonexistent.json"),
+            expect_fail=True,
+        )
+
+    def test_form_empty_tasks_fails(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan(tasks=[])
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        run(
+            "form", "--mission-dir", str(mission_dir), "--plan", str(plan_path),
+            expect_fail=True,
+        )
+
+    def test_form_missing_squadron_fails(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = {"tasks": [{"id": 1, "name": "T", "owner": "X", "deliverable": "D",
+                           "dependencies": [], "station_tier": 0, "file_ownership": []}]}
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        run(
+            "form", "--mission-dir", str(mission_dir), "--plan", str(plan_path),
+            expect_fail=True,
+        )
+
+    def test_form_with_dependencies(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan(
+            captains=[
+                {"ship_name": "HMS Argyll", "ship_class": "frigate", "model": "sonnet", "task_id": 1},
+                {"ship_name": "HMS Kent", "ship_class": "destroyer", "model": "sonnet", "task_id": 2},
+            ],
+            tasks=[
+                {"id": 1, "name": "A", "owner": "HMS Argyll", "deliverable": "D1",
+                 "dependencies": [], "station_tier": 0, "file_ownership": []},
+                {"id": 2, "name": "B", "owner": "HMS Kent", "deliverable": "D2",
+                 "dependencies": [1], "station_tier": 1, "file_ownership": []},
+            ],
+        )
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        result = run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        bp = read_json(mission_dir / "battle-plan.json")
+        assert bp["tasks"][0]["dependents"] == [2]
+        assert bp["tasks"][1]["dependencies"] == [1]
+
+    def test_form_with_red_cell(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan(red_cell={"ship_name": "HMS Astute", "model": "haiku"})
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        result = run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        summary = json.loads(result.stdout)
+        assert summary["squadron"]["has_red_cell"] is True
+        bp = read_json(mission_dir / "battle-plan.json")
+        assert bp["squadron"]["red_cell"]["ship_name"] == "HMS Astute"
+
+    def test_form_runs_conflict_scan(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan()
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        result = run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        summary = json.loads(result.stdout)
+        assert "conflict_scan" in summary
+        assert isinstance(summary["conflict_scan"]["clean"], bool)
+
+
+# ---------------------------------------------------------------------------
+# Headless (init + form)
+# ---------------------------------------------------------------------------
+
+
+def write_sailing_orders_json(path: Path, orders: dict) -> None:
+    """Write a sailing orders JSON file."""
+    path.write_text(json.dumps(orders), encoding="utf-8")
+
+
+def make_sailing_orders(
+    outcome: str = "Test mission",
+    metric: str = "All tests pass",
+    deadline: str = "this_session",
+    token_budget: int | None = 100000,
+) -> dict:
+    """Build sailing orders suitable for headless command."""
+    result: dict = {
+        "outcome": outcome,
+        "metric": metric,
+        "deadline": deadline,
+    }
+    if token_budget is not None:
+        result["budget"] = {"token_limit": token_budget}
+    return result
+
+
+class TestHeadless:
+    def test_headless_creates_mission(self, tmp_path: Path) -> None:
+        so = make_sailing_orders()
+        plan = make_plan()
+        so_path = tmp_path / "sailing-orders.json"
+        plan_path = tmp_path / "plan.json"
+        write_sailing_orders_json(so_path, so)
+        write_plan_json(plan_path, plan)
+        result = run(
+            "headless",
+            "--sailing-orders", str(so_path),
+            "--battle-plan", str(plan_path),
+            "--mode", "subagents",
+            "--auto-approve",
+            cwd=tmp_path,
+        )
+        summary = json.loads(result.stdout)
+        assert summary["status"] == "ok"
+        mission_dir = tmp_path / summary["mission_dir"]
+        assert mission_dir.is_dir()
+        assert (mission_dir / "sailing-orders.json").exists()
+        assert (mission_dir / "battle-plan.json").exists()
+        assert (mission_dir / "fleet-status.json").exists()
+
+    def test_headless_outputs_json(self, tmp_path: Path) -> None:
+        so = make_sailing_orders()
+        plan = make_plan()
+        so_path = tmp_path / "sailing-orders.json"
+        plan_path = tmp_path / "plan.json"
+        write_sailing_orders_json(so_path, so)
+        write_plan_json(plan_path, plan)
+        result = run(
+            "headless",
+            "--sailing-orders", str(so_path),
+            "--battle-plan", str(plan_path),
+            "--mode", "subagents",
+            "--auto-approve",
+            cwd=tmp_path,
+        )
+        summary = json.loads(result.stdout)
+        assert "mission_dir" in summary
+        assert "sailing_orders" in summary
+        assert summary["sailing_orders"]["outcome"] == "Test mission"
+        assert "formation" in summary
+
+    def test_headless_missing_sailing_orders_fails(self, tmp_path: Path) -> None:
+        plan = make_plan()
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        run(
+            "headless",
+            "--sailing-orders", str(tmp_path / "nonexistent.json"),
+            "--battle-plan", str(plan_path),
+            "--mode", "subagents",
+            "--auto-approve",
+            cwd=tmp_path,
+            expect_fail=True,
+        )
+
+    def test_headless_missing_battle_plan_fails(self, tmp_path: Path) -> None:
+        so = make_sailing_orders()
+        so_path = tmp_path / "sailing-orders.json"
+        write_sailing_orders_json(so_path, so)
+        run(
+            "headless",
+            "--sailing-orders", str(so_path),
+            "--battle-plan", str(tmp_path / "nonexistent.json"),
+            "--mode", "subagents",
+            "--auto-approve",
+            cwd=tmp_path,
+            expect_fail=True,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Full Lifecycle Integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements #79 — consolidates the multi-step formation phase into composite commands.

- **`nelson-data.py form`** — single command that registers tasks, records squadron, computes DAG metrics, and runs conflict scan. Replaces 4-8+ sequential Bash calls with one.
- **`nelson-data.py headless`** — combines `init` + `form`, reads sailing orders and battle plan from JSON files. Enables CI/CD pipeline integration.
- **Extracted core logic** from `cmd_task`, `cmd_squadron`, `cmd_plan_approved` into reusable functions (`_build_task_record`, `_register_tasks`, `_register_squadron`, `_finalize_plan`, `_do_init`). Existing commands are now thin wrappers — backward compatible.
- **Fixed conflict scan key mismatch** — `nelson_conflict_scan.py` now reads `file_ownership` (matching battle-plan.json) with `files` fallback.
- **Updated docs** — `structured-data.md` documents new commands; SKILL.md Step 3 recommends `form`; Step 4 headless note updated.

## Test plan

- [x] 15 new tests added (10 `TestForm`, 4 `TestHeadless`, 1 `TestConflictScan`)
- [x] All 91 tests pass (`pytest skills/nelson/scripts/ -v`)
- [x] All 66 original tests unchanged and passing (backward compatibility)
- [ ] Manual smoke test: `form` with a real plan JSON
- [ ] Manual smoke test: `headless` end-to-end
- [ ] CI pipeline passes (markdown lint, YAML lint, link check, spell check, Python tests)