### PR TITLE
feat: path-scoped auto-discovery + dynamic context injection

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -5,11 +5,11 @@ argument-hint: "[mission description]"
 paths: [".nelson/**"]
 ---
 
+# Nelson
+
 ```!
 python3 "{skill-dir}/scripts/nelson-data.py" status --mission-dir "$(ls -td .nelson/missions/*/ 2>/dev/null | head -1)" || echo "No active missions"
 ```
-
-# Nelson
 
 Execute this workflow for the user's mission.
 

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -6,7 +6,7 @@ paths: [".nelson/**"]
 ---
 
 ```!
-python3 {skill-dir}/scripts/nelson-data.py status --mission-dir $(ls -td .nelson/missions/*/ 2>/dev/null | head -1) 2>/dev/null || echo "No active missions"
+python3 "{skill-dir}/scripts/nelson-data.py" status --mission-dir "$(ls -td .nelson/missions/*/ 2>/dev/null | head -1)" || echo "No active missions"
 ```
 
 # Nelson

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -2,7 +2,12 @@
 name: nelson
 description: Orchestrates multi-agent task execution using a Royal Navy squadron metaphor — from mission planning through parallel work coordination to stand-down. Use when work needs parallel agent orchestration, tight task coordination with quality gates, structured delegation with progress checkpoints, or a documented decision log.
 argument-hint: "[mission description]"
+paths: [".nelson/**"]
 ---
+
+```!
+python3 {skill-dir}/scripts/nelson-data.py status --mission-dir $(ls -td .nelson/missions/*/ 2>/dev/null | head -1) 2>/dev/null || echo "No active missions"
+```
 
 # Nelson
 

--- a/skills/nelson/references/structured-data.md
+++ b/skills/nelson/references/structured-data.md
@@ -111,13 +111,24 @@ python3 .claude/skills/nelson/scripts/nelson-data.py stand-down \
 
 ### `status` — Print current fleet status (read-only)
 
-Run at any time for a quick status check. Useful for session resumption and hooks.
+Run at any time for a quick status check. Useful for session resumption, hooks, and dynamic context injection. Auto-invoked by SKILL.md's `!` block on skill activation.
 
-Reads `fleet-status.json` and prints a compact summary. Silent no-op if no mission data exists.
+Reads `fleet-status.json` and `mission-log.json` to produce a compact briefing with per-ship status and elapsed time. Silent no-op if no mission data exists. The `--mission-dir` argument is optional — omitting it is a silent no-op.
 
 ```bash
 python3 .claude/skills/nelson/scripts/nelson-data.py status \
   --mission-dir .nelson/missions/2026-03-27_120000_a1b2c3d4
+```
+
+Example output:
+
+```
+NELSON FLEET STATUS
+Mission: 2026-04-08_201214_a1b2c3d4 (underway)
+Progress: 3/5 tasks complete | 1 blocked
+Ships: HMS Argyll (Green 82%) | HMS Kent (Amber 65%) | HMS Daring (completed)
+Last checkpoint: 2 (12 min ago)
+Budget: 45% consumed
 ```
 
 ## Write Timing

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -252,6 +252,33 @@ def _get_last_checkpoint_number(events: list[dict]) -> int:
     return max(nums) if nums else 0
 
 
+def _format_elapsed(iso_timestamp: str) -> str:
+    """Format an ISO timestamp as a relative elapsed string, e.g. '12 min ago'.
+
+    Returns an empty string if the timestamp cannot be parsed.
+    """
+    if not iso_timestamp:
+        return ""
+    try:
+        then = datetime.fromisoformat(iso_timestamp.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        delta_seconds = int((now - then).total_seconds())
+        if delta_seconds < 0:
+            return ""
+        if delta_seconds < 60:
+            return f"{delta_seconds} sec ago"
+        minutes = delta_seconds // 60
+        if minutes < 60:
+            return f"{minutes} min ago"
+        hours = minutes // 60
+        remaining_min = minutes % 60
+        if remaining_min == 0:
+            return f"{hours} hr ago"
+        return f"{hours} hr {remaining_min} min ago"
+    except (ValueError, TypeError):
+        return ""
+
+
 # ---------------------------------------------------------------------------
 # Fleet Intelligence — Helpers
 # ---------------------------------------------------------------------------
@@ -1145,40 +1172,64 @@ def cmd_status(args: argparse.Namespace) -> None:
     mission = fs.get("mission", {})
     progress = fs.get("progress", {})
     budget = fs.get("budget", {})
+    squadron = fs.get("squadron", [])
 
+    # Mission identity
+    mission_name = mission_dir.name
     status = mission.get("status", "unknown")
-    cp = mission.get("checkpoint_number", 0)
+
+    # Progress
     completed = progress.get("completed", 0)
     total = progress.get("total", 0)
-    pct = budget.get("pct_consumed", 0.0)
-    spent = budget.get("tokens_spent", 0)
+    blocked = progress.get("blocked", 0)
 
-    squadron = fs.get("squadron", [])
-    hull_counts = {"G": 0, "A": 0, "R": 0, "C": 0}
+    # Determine completed ships from mission-log events
+    completed_ships: set[str] = set()
+    log_path = mission_dir / "mission-log.json"
+    if log_path.exists():
+        log = _read_json(log_path)
+        for event in log.get("events", []):
+            if event.get("type") == "task_completed":
+                owner = event.get("data", {}).get("owner", "")
+                if owner:
+                    completed_ships.add(owner)
+
+    # Per-ship status
+    ship_parts: list[str] = []
     for ship in squadron:
-        hull_status = ship.get("hull_integrity_status", "Green")
-        if hull_status == "Green":
-            hull_counts["G"] += 1
-        elif hull_status == "Amber":
-            hull_counts["A"] += 1
-        elif hull_status == "Red":
-            hull_counts["R"] += 1
-        elif hull_status == "Critical":
-            hull_counts["C"] += 1
+        name = ship.get("ship_name", "unknown")
+        if name in completed_ships:
+            ship_parts.append(f"{name} (completed)")
+        else:
+            hull_status = ship.get("hull_integrity_status", "Green")
+            hull_pct = ship.get("hull_integrity_pct", 100)
+            ship_parts.append(f"{name} ({hull_status} {hull_pct}%)")
+    ships_str = " | ".join(ship_parts) if ship_parts else "none"
 
-    blockers = len(fs.get("blockers", []))
+    # Checkpoint and time-since
+    cp = mission.get("checkpoint_number", 0)
+    elapsed_str = _format_elapsed(fs.get("last_updated", ""))
 
-    hull_str = (
-        f"{hull_counts['G']}G {hull_counts['A']}A "
-        f"{hull_counts['R']}R {hull_counts['C']}C"
-    )
+    # Budget
+    pct = budget.get("pct_consumed", 0.0)
+
+    # Format output
+    progress_parts = [f"{completed}/{total} tasks complete"]
+    if blocked > 0:
+        progress_parts.append(f"{blocked} blocked")
+    progress_str = " | ".join(progress_parts)
+
+    checkpoint_str = f"Last checkpoint: {cp}"
+    if elapsed_str:
+        checkpoint_str += f" ({elapsed_str})"
 
     print(
-        f"[nelson-data] Status: {status} (checkpoint {cp})\n"
-        f"Fleet: {completed}/{total} done | "
-        f"Budget: {pct}% ({spent} tokens) | "
-        f"Hull: {hull_str} | "
-        f"Blockers: {blockers}"
+        f"NELSON FLEET STATUS\n"
+        f"Mission: {mission_name} ({status})\n"
+        f"Progress: {progress_str}\n"
+        f"Ships: {ships_str}\n"
+        f"{checkpoint_str}\n"
+        f"Budget: {pct}% consumed"
     )
 
 
@@ -1654,7 +1705,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # --- status ---
     p_st = subs.add_parser("status", help="Print current fleet status")
-    p_st.add_argument("--mission-dir", required=True, help="Mission directory path")
+    p_st.add_argument("--mission-dir", default="", help="Mission directory path")
 
     # --- index ---
     p_idx = subs.add_parser("index", help="Build fleet intelligence index")

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -1229,7 +1229,7 @@ def cmd_status(args: argparse.Namespace) -> None:
         f"Progress: {progress_str}\n"
         f"Ships: {ships_str}\n"
         f"{checkpoint_str}\n"
-        f"Budget: {pct}% consumed"
+        f"Budget: {pct:.0f}% consumed"
     )
 
 

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -623,6 +623,86 @@ class TestStatus:
 
 
 # ---------------------------------------------------------------------------
+# _format_elapsed unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatElapsed:
+    """Direct unit tests for _format_elapsed() helper."""
+
+    @staticmethod
+    def _import_format_elapsed():
+        """Import _format_elapsed from nelson-data.py."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("nelson_data", str(SCRIPT))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod._format_elapsed, mod
+
+    def test_empty_string_returns_empty(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        assert fn("") == ""
+
+    def test_none_returns_empty(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        assert fn(None) == ""
+
+    def test_unparseable_returns_empty(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        assert fn("not-a-date") == ""
+
+    def test_future_timestamp_returns_empty(self) -> None:
+        fn, mod = self._import_format_elapsed()
+        from datetime import datetime, timezone, timedelta
+
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        assert fn(future) == ""
+
+    def test_seconds_ago(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        from datetime import datetime, timezone, timedelta
+
+        ts = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+        result = fn(ts)
+        assert "sec ago" in result
+
+    def test_minutes_ago(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        from datetime import datetime, timezone, timedelta
+
+        ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        result = fn(ts)
+        assert "min ago" in result
+        assert "5 min ago" == result
+
+    def test_hours_exact(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        from datetime import datetime, timezone, timedelta
+
+        ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        result = fn(ts)
+        assert result == "2 hr ago"
+
+    def test_hours_and_minutes(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        from datetime import datetime, timezone, timedelta
+
+        ts = (datetime.now(timezone.utc) - timedelta(hours=1, minutes=30)).isoformat()
+        result = fn(ts)
+        assert result == "1 hr 30 min ago"
+
+    def test_zulu_suffix_parsed(self) -> None:
+        fn, _ = self._import_format_elapsed()
+        from datetime import datetime, timezone, timedelta
+
+        dt = datetime.now(timezone.utc) - timedelta(minutes=10)
+        ts = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = fn(ts)
+        assert "10 min ago" == result
+
+
+# ---------------------------------------------------------------------------
 # Full Lifecycle Integration
 # ---------------------------------------------------------------------------
 

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -518,7 +518,11 @@ class TestStatus:
             "--decision", "continue", "--rationale", "Test",
         )
         result = run("status", "--mission-dir", str(mission_dir))
-        assert "Status:" in result.stdout or "nelson-data" in result.stdout
+        assert "NELSON FLEET STATUS" in result.stdout
+        assert "underway" in result.stdout
+        assert "1/3 tasks complete" in result.stdout
+        assert "Budget:" in result.stdout
+        assert "Last checkpoint: 1" in result.stdout
 
     def test_status_no_fleet_data_is_silent(self, tmp_path: Path) -> None:
         """Status on a mission with no fleet-status.json is a silent no-op (rc=0)."""
@@ -527,6 +531,95 @@ class TestStatus:
         result = run("status", "--mission-dir", str(mission_dir))
         # Silent no-op — no output, no error
         assert result.stdout.strip() == ""
+
+    def test_status_shows_per_ship_status(self, tmp_path: Path) -> None:
+        """Status output includes per-ship hull status."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir, captains=[
+            "HMS Argyll:frigate:sonnet:1",
+            "HMS Kent:destroyer:sonnet:2",
+        ])
+        add_task(mission_dir, task_id=1, name="Task A", owner="HMS Argyll")
+        add_task(mission_dir, task_id=2, name="Task B", owner="HMS Kent")
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "0", "--in-progress", "1", "--completed", "1", "--blocked", "0",
+            "--tokens-spent", "40000", "--tokens-remaining", "60000",
+            "--hull-green", "2", "--hull-amber", "0", "--hull-red", "0", "--hull-critical", "0",
+            "--decision", "continue", "--rationale", "Test",
+        )
+        result = run("status", "--mission-dir", str(mission_dir))
+        assert "HMS Argyll" in result.stdout
+        assert "HMS Kent" in result.stdout
+        assert "Ships:" in result.stdout
+
+    def test_status_shows_completed_ships(self, tmp_path: Path) -> None:
+        """Ships whose tasks are complete show (completed) in status."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir, captains=[
+            "HMS Argyll:frigate:sonnet:1",
+            "HMS Kent:destroyer:sonnet:2",
+        ])
+        add_task(mission_dir, task_id=1, name="Task A", owner="HMS Argyll")
+        add_task(mission_dir, task_id=2, name="Task B", owner="HMS Kent")
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        # Record task completion event for HMS Argyll
+        run(
+            "event",
+            "--mission-dir", str(mission_dir),
+            "--type", "task_completed",
+            "--checkpoint", "1",
+            "--task-id", "1", "--task-name", "Task A", "--owner", "HMS Argyll",
+            "--station-tier", "0", "--verification", "passed",
+        )
+        run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "0", "--in-progress", "1", "--completed", "1", "--blocked", "0",
+            "--tokens-spent", "50000", "--tokens-remaining", "50000",
+            "--hull-green", "1", "--hull-amber", "0", "--hull-red", "0", "--hull-critical", "0",
+            "--decision", "continue", "--rationale", "Test",
+        )
+        result = run("status", "--mission-dir", str(mission_dir))
+        assert "HMS Argyll (completed)" in result.stdout
+        assert "HMS Kent (Green" in result.stdout
+
+    def test_status_shows_mission_name(self, tmp_path: Path) -> None:
+        """Status output includes the mission directory name."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "0", "--in-progress", "0", "--completed", "1", "--blocked", "0",
+            "--tokens-spent", "10000", "--tokens-remaining", "90000",
+            "--hull-green", "1", "--hull-amber", "0", "--hull-red", "0", "--hull-critical", "0",
+            "--decision", "continue", "--rationale", "Test",
+        )
+        result = run("status", "--mission-dir", str(mission_dir))
+        assert f"Mission: {mission_dir.name}" in result.stdout
+
+    def test_status_no_mission_dir_is_silent(self, tmp_path: Path) -> None:
+        """Status without --mission-dir is a silent no-op."""
+        result = run("status", cwd=tmp_path)
+        assert result.stdout.strip() == ""
+
+    def test_status_shows_blocked_count(self, tmp_path: Path) -> None:
+        """Status shows blocked count when blockers exist."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "1", "--in-progress", "0", "--completed", "1", "--blocked", "1",
+            "--tokens-spent", "30000", "--tokens-remaining", "70000",
+            "--hull-green", "1", "--hull-amber", "0", "--hull-red", "0", "--hull-critical", "0",
+            "--decision", "continue", "--rationale", "Test",
+        )
+        result = run("status", "--mission-dir", str(mission_dir))
+        assert "1 blocked" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -648,7 +648,7 @@ class TestFormatElapsed:
         fn, _ = self._import_format_elapsed()
         assert fn(None) == ""
 
-    def test_unparseable_returns_empty(self) -> None:
+    def test_unparsable_returns_empty(self) -> None:
         fn, _ = self._import_format_elapsed()
         assert fn("not-a-date") == ""
 


### PR DESCRIPTION
## Summary

- Add `paths: [".nelson/**"]` to SKILL.md frontmatter for automatic Nelson activation when a `.nelson/` directory exists
- Add dynamic context injection via `!` code block that runs `nelson-data.py status` against the most recent mission, injecting fleet status as a briefing prefix on skill load
- Enhance `cmd_status` output with mission name, per-ship hull status, completed ship detection, relative elapsed time, and conditional blocked count
- Make `--mission-dir` optional on the status parser for graceful no-op when no missions exist
- Update structured-data.md reference documentation with new format and example output

## Test plan

- [x] All 71 existing tests pass (no regressions)
- [x] 5 new tests added for enhanced status output (per-ship, completed ships, mission name, no-mission-dir, blocked count)
- [x] Updated existing `test_status_after_checkpoint` to assert new format
- [ ] Manual: verify `paths:` triggers auto-activation in a project with `.nelson/` directory
- [ ] Manual: verify `!` block injects fleet status on skill load
- [ ] Manual: verify silent no-op when no `.nelson/` directory exists

Closes #80