### PR TITLE
feat: automated budget circuit breakers (#85)

### DIFF
--- a/hooks/nelson_hooks.py
+++ b/hooks/nelson_hooks.py
@@ -568,6 +568,7 @@ def cmd_idle_ship(args: argparse.Namespace) -> None:
             f"Check hull integrity and task status.",
             file=sys.stderr,
         )
+        _check_idle_circuit_breaker(mission_dir, teammate_name)
         _allow()
 
     ship_name = ship.get("ship_name", teammate_name)
@@ -582,12 +583,15 @@ def cmd_idle_ship(args: argparse.Namespace) -> None:
                 f"See references/standing-orders/paid-off.md.",
                 file=sys.stderr,
             )
+            # Completed ships don't need an idle-timeout advisory — clear tracker.
+            _clear_idle_tracker(mission_dir, ship_name)
         else:
             print(
                 f"{ship_name} task is complete but has pending dependent "
                 f"tasks. Hold position until dependents are evaluated.",
                 file=sys.stderr,
             )
+            _check_idle_circuit_breaker(mission_dir, ship_name)
     else:
         hull = ship.get("hull_integrity_status", "unknown")
         print(
@@ -595,8 +599,58 @@ def cmd_idle_ship(args: argparse.Namespace) -> None:
             f"(hull: {hull}). Check hull integrity and task progress.",
             file=sys.stderr,
         )
+        _check_idle_circuit_breaker(mission_dir, ship_name)
 
     _allow()
+
+
+def _check_idle_circuit_breaker(mission_dir: Path, ship_name: str) -> None:
+    """Run the idle-timeout circuit breaker and surface an advisory if tripped.
+
+    Imports are local so the hook stays fast and has no hard dependency on
+    the scripts directory being importable (the hook degrades gracefully).
+    """
+    if not ship_name:
+        return
+    try:
+        sys.path.insert(
+            0, str(Path(__file__).resolve().parent.parent / "skills" / "nelson" / "scripts")
+        )
+        from nelson_circuit_breakers import (  # type: ignore[import-not-found]
+            evaluate_idle_timeout,
+            load_config,
+        )
+    except ImportError:
+        return
+
+    sailing_orders = _read_json(mission_dir / "sailing-orders.json") or None
+    config = load_config(sailing_orders)
+    if not config.get("enabled", True):
+        return
+
+    from datetime import datetime, timezone
+
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    trip = evaluate_idle_timeout(mission_dir, ship_name, now_iso, config)
+    if trip is None:
+        return
+
+    print(
+        f"[CIRCUIT BREAKER: {trip.type}] {trip.message}",
+        file=sys.stderr,
+    )
+
+
+def _clear_idle_tracker(mission_dir: Path, ship_name: str) -> None:
+    """Best-effort: clear the idle tracker entry for a completed ship."""
+    try:
+        sys.path.insert(
+            0, str(Path(__file__).resolve().parent.parent / "skills" / "nelson" / "scripts")
+        )
+        from nelson_circuit_breakers import clear_idle_tracker  # type: ignore[import-not-found]
+    except ImportError:
+        return
+    clear_idle_tracker(mission_dir, ship_name)
 
 
 # ---------------------------------------------------------------------------

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -315,6 +315,7 @@ Consult the specific procedure that matches the situation.
 | Ship's crew consuming disproportionate tokens or time | `references/damage-control/crew-overrun.md` |
 | Ship's context window depleted, needs replacement | `references/damage-control/relief-on-station.md` |
 | Ship context window approaching limits | `references/damage-control/hull-integrity.md` |
+| Automated budget, hull, and idle alarms crossing thresholds | `references/damage-control/circuit-breakers.md` |
 | Preparing the mission directory at session start | `references/damage-control/session-hygiene.md` |
 | Agent team communication failure (lost agent IDs, message bus down) | `references/damage-control/comms-failure.md` |
 

--- a/skills/nelson/references/damage-control/circuit-breakers.md
+++ b/skills/nelson/references/damage-control/circuit-breakers.md
@@ -1,0 +1,114 @@
+# Circuit Breakers: Automated Budget Alarms
+
+Use to supplement the admiral's checkpoint rhythm with automatic, threshold-based alarms. Circuit breakers surface advisories when resource thresholds are crossed — they do not abort ships or auto-execute damage control. The admiral decides the remedy.
+
+## What They Are
+
+Circuit breakers are a set of named thresholds evaluated at two points:
+
+1. **At each quarterdeck checkpoint**, by `nelson-data.py checkpoint`, against the freshly-written `fleet-status.json` and mission log.
+2. **On `TeammateIdle` hook fires**, for per-ship idle timeouts, via the `idle-ship` hook handler.
+
+When a threshold is crossed, a `circuit_breaker_tripped` event is appended to `mission-log.json` with the value, the threshold, and the recommended damage control procedure. The admiral sees a single advisory line per trip on stdout (or stderr for the idle-ship hook) and decides what to do.
+
+Circuit breakers are advisory in the current release. A future `strict` mode may auto-trigger relief on station for hull breaches or auto-abort on catastrophic budget overrun.
+
+## Thresholds and Defaults
+
+| Threshold | Default | Evaluated at | Recommends |
+|---|---|---|---|
+| `hull_integrity_threshold` — any ship hull ≤ N% | 80 | checkpoint | `damage-control/hull-integrity.md` |
+| `budget_alarm_ratio` / `budget_alarm_completion_ratio` — tokens spent ≥ R1 of limit AND tasks completed < R2 of total | 0.7 / 0.4 | checkpoint | admiral review, elevate to Station 2 |
+| `cost_per_task_multiplier` — latest burn/task ≥ N × rolling median (needs `cost_per_task_min_history` checkpoints of history) | 3.0 / 3 | checkpoint | `damage-control/crew-overrun.md` |
+| `consecutive_failures` — `blocker_raised` events without an intervening `blocker_resolved` ≥ N | 2 | checkpoint | `damage-control/scuttle-and-reform.md` |
+| `idle_timeout_minutes` — a single ship idle for ≥ N minutes with incomplete task | 10 | TeammateIdle hook | `damage-control/man-overboard.md` |
+| `time_limit_grace_minutes` — mission duration ≥ `sailing_orders.budget.time_limit_minutes` + grace | 0 | checkpoint | admiral review, consider stand-down |
+
+The `enabled` key (default `true`) is a master switch.
+
+## Configuration
+
+Circuit breaker thresholds live under `sailing-orders.json > circuit_breakers`. The admiral can edit this file directly after `nelson-data init`:
+
+```json
+{
+  "version": 1,
+  "outcome": "...",
+  "budget": {"token_limit": 100000, "time_limit_minutes": 120},
+  "circuit_breakers": {
+    "hull_integrity_threshold": 75,
+    "budget_alarm_ratio": 0.75,
+    "idle_timeout_minutes": 5,
+    "enabled": true
+  }
+}
+```
+
+Unknown keys are silently ignored so typos cannot secretly override defaults. Missing keys fall back to the defaults in `nelson_circuit_breakers.py`.
+
+To disable all circuit breakers for a mission (e.g. a smoke test mission), set `enabled: false`.
+
+## Output Format
+
+When a checkpoint trips a breaker, `nelson-data.py checkpoint` prints one line per trip to stdout after the checkpoint summary:
+
+```
+[nelson-data] Checkpoint 3 recorded
+Fleet: 1/4 done | Budget: 80.0% | Hull: 4G 0A 0R 0C | Blockers: 0
+[CIRCUIT BREAKER: budget_alarm] Budget alarm: 80% of tokens spent with only 25% of tasks complete. Elevate to Station 2 and review scope.
+```
+
+The same trip is appended to `mission-log.json` as:
+
+```json
+{
+  "type": "circuit_breaker_tripped",
+  "checkpoint": 3,
+  "timestamp": "2026-04-11T12:34:56Z",
+  "data": {
+    "type": "budget_alarm",
+    "value": {"spent_ratio": 0.8, "completion_ratio": 0.25},
+    "threshold": {"spent_ratio": 0.7, "completion_ratio": 0.4},
+    "action": "admiral-review",
+    "message": "Budget alarm: 80% of tokens spent with only 25% of tasks complete. ..."
+  }
+}
+```
+
+This record is the authoritative trail for post-mission analysis — `nelson-data history` and the cross-mission memory store will see circuit breaker events and can correlate them with outcomes.
+
+## Idle Timeout: How the Hook Tracks State
+
+The `TeammateIdle` hook does not receive an idle duration in its payload. To compute elapsed idle time, the circuit breaker keeps a small state file at `<mission-dir>/idle-tracker.json`:
+
+1. First time `TeammateIdle` fires for ship X → record `{X: "2026-04-11T12:00:00Z"}` and emit no advisory.
+2. Subsequent fires → compute elapsed from the stored timestamp. If elapsed ≥ `idle_timeout_minutes`, emit the man-overboard advisory.
+3. When a ship's task becomes `completed` (the paid-off standing order path), its tracker entry is cleared.
+
+Tracker state is best-effort: if the file cannot be written, the breaker silently degrades.
+
+## Fleet-Status Budget Extensions
+
+Each checkpoint now writes two new fields under `fleet-status.json > budget`:
+
+- `burn_rate_per_task` — `tokens_spent / completed`, rounded to integer. `None` when no tasks have completed.
+- `projected_budget_at_completion` — `burn_rate_per_task × total`. `None` when `burn_rate_per_task` is `None` or `total == 0`.
+
+These are advisory projections, not guarantees. They exist so the admiral (and any future planner) can read a single field and see where the mission is heading without re-computing from raw counters.
+
+## When Circuit Breakers Are Not Enough
+
+Circuit breakers are a backstop, not a substitute for:
+
+- The quarterdeck checkpoint rhythm — breakers run at checkpoint time but the admiral still owns the decision.
+- Hull integrity reports — breakers detect a breach only if the ship has filed a damage report or the squadron readiness board has been updated.
+- Standing orders — breakers do not evaluate anti-patterns; that is the admiral's standing-order check at each decision point.
+
+If a circuit breaker fires repeatedly for the same root cause, that is signal that a new standing order may be warranted. See `docs/` for how standing orders are added.
+
+## Relationship to Other Procedures
+
+- **Hull integrity** (`hull-integrity.md`): the hull-integrity circuit breaker is a secondary alarm on top of the damage-report-driven readiness board. It catches misses.
+- **Crew overrun** (`crew-overrun.md`): the cost-per-task circuit breaker detects overruns by burn-rate spike rather than by captain self-report.
+- **Man overboard** (`man-overboard.md`): the idle-timeout circuit breaker catches stuck ships the admiral has not yet noticed.
+- **Scuttle and reform** (`scuttle-and-reform.md`): the consecutive-failures circuit breaker triggers this consideration without the admiral having to count blockers manually.

--- a/skills/nelson/references/damage-control/crew-overrun.md
+++ b/skills/nelson/references/damage-control/crew-overrun.md
@@ -11,3 +11,5 @@ Use when a ship's crew is consuming disproportionate tokens or time relative to 
    - If role mismatch: reassign the sub-task to the correct role or handle it directly.
 5. Captain resumes crew activity with a revised budget allocation.
 6. If the ship cannot recover within budget, captain escalates to admiral with a summary and recommendation: extend budget, descope the ship's task, or split the remaining work into a second ship.
+
+See `damage-control/circuit-breakers.md` for the automated `cost_per_task_overrun` alarm that can catch overruns between captain self-reports.

--- a/skills/nelson/references/damage-control/hull-integrity.md
+++ b/skills/nelson/references/damage-control/hull-integrity.md
@@ -66,6 +66,10 @@ Hull integrity monitoring works alongside existing damage control procedures:
 - **Man Overboard** (`man-overboard.md`): Replacing a stuck agent consumes additional context. Factor hull integrity into the decision to replace versus descope.
 - **Scuttle and Reform** (`scuttle-and-reform.md`): When the flagship reaches Red and multiple ships are also at Red or Critical, consider scuttling the current mission and reforming with fresh context rather than attempting piecemeal relief.
 
+## Automated Circuit Breaker
+
+In addition to the damage-report-driven readiness board, Nelson's automated circuit breakers emit a `hull_integrity_breach` advisory at each checkpoint when any ship's `hull_integrity_pct` falls at or below `circuit_breakers.hull_integrity_threshold` (default 80%). See `damage-control/circuit-breakers.md` for thresholds, configuration, and output format.
+
 ## Advanced: TeammateIdle Hook
 
 Nelson ships a `TeammateIdle` hook in `hooks/hooks.json` that triggers an

--- a/skills/nelson/scripts/nelson_circuit_breakers.py
+++ b/skills/nelson/scripts/nelson_circuit_breakers.py
@@ -1,0 +1,483 @@
+"""Automated budget circuit breakers for Nelson missions.
+
+Evaluates a set of configurable thresholds against mission state and returns
+a list of ``BreakerTrip`` records describing which thresholds were crossed
+and which damage control procedures are recommended. This module is pure —
+callers are responsible for appending events, updating fleet status, or
+surfacing advisories.
+
+Thresholds implemented:
+
+* ``hull_integrity_breach``   — any ship's hull_integrity_pct <= threshold
+* ``budget_alarm``            — tokens_spent/budget >= ratio AND
+                                completed/total < completion ratio
+* ``cost_per_task_overrun``   — burn rate per task >= multiplier * rolling
+                                median of previous checkpoints
+* ``consecutive_failures``    — consecutive ``blocker_raised`` events without
+                                an intervening ``blocker_resolved`` >= N
+* ``time_limit``              — mission duration_minutes >= configured limit
+* ``idle_timeout``            — evaluated by the TeammateIdle hook via
+                                ``evaluate_idle_timeout``; tracks first-seen
+                                idle time per ship in ``idle-tracker.json``
+
+Circuit breakers are **advisory** in this iteration: they emit events and
+surface alarms, but do not abort ships or auto-trigger damage control. A
+future ``strict`` mode is out of scope.
+
+No external dependencies — stdlib only.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Defaults & config
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_THRESHOLDS: dict[str, Any] = {
+    "enabled": True,
+    "hull_integrity_threshold": 80,
+    "budget_alarm_ratio": 0.7,
+    "budget_alarm_completion_ratio": 0.4,
+    "cost_per_task_multiplier": 3.0,
+    "cost_per_task_min_history": 3,
+    "consecutive_failures": 2,
+    "idle_timeout_minutes": 10,
+    "time_limit_grace_minutes": 0,
+}
+
+
+def load_config(sailing_orders: dict[str, Any] | None) -> dict[str, Any]:
+    """Merge user-supplied circuit breaker config with defaults.
+
+    Unknown keys from *sailing_orders* are dropped so typos do not silently
+    override defaults.
+    """
+    merged = dict(DEFAULT_THRESHOLDS)
+    if not sailing_orders:
+        return merged
+    user = sailing_orders.get("circuit_breakers") or {}
+    for key, value in user.items():
+        if key in DEFAULT_THRESHOLDS:
+            merged[key] = value
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Trip record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BreakerTrip:
+    """Structured record of a threshold crossing."""
+
+    type: str
+    value: Any
+    threshold: Any
+    action: str
+    message: str
+    context: dict[str, Any] = field(default_factory=dict)
+
+    def to_event_data(self) -> dict[str, Any]:
+        """Serialise for appending to mission-log.json."""
+        return {
+            "type": self.type,
+            "value": self.value,
+            "threshold": self.threshold,
+            "action": self.action,
+            "message": self.message,
+            "context": self.context,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Evaluator — called at checkpoint time
+# ---------------------------------------------------------------------------
+
+
+def evaluate(
+    fleet_status: dict[str, Any],
+    sailing_orders: dict[str, Any] | None,
+    mission_log_events: list[dict[str, Any]],
+    now_iso: str,
+) -> list[BreakerTrip]:
+    """Evaluate all checkpoint-time thresholds and return any trips.
+
+    *fleet_status* is the freshly-written fleet-status.json dict.
+    *sailing_orders* is the sailing-orders.json dict (may be None).
+    *mission_log_events* is the full events list from mission-log.json.
+    *now_iso* is the current time stamp in ISO 8601 UTC.
+    """
+    config = load_config(sailing_orders)
+    if not config.get("enabled", True):
+        return []
+
+    trips: list[BreakerTrip] = []
+
+    trips.extend(_check_hull_integrity(fleet_status, config))
+    trips.extend(_check_budget_alarm(fleet_status, sailing_orders, config))
+    trips.extend(_check_cost_per_task_overrun(mission_log_events, config))
+    trips.extend(_check_consecutive_failures(mission_log_events, config))
+    trips.extend(_check_time_limit(fleet_status, sailing_orders, config, now_iso))
+
+    return trips
+
+
+def _check_hull_integrity(
+    fleet_status: dict[str, Any], config: dict[str, Any]
+) -> list[BreakerTrip]:
+    """Any ship at or below the hull integrity threshold trips the breaker."""
+    threshold = config["hull_integrity_threshold"]
+    trips: list[BreakerTrip] = []
+    for ship in fleet_status.get("squadron", []):
+        pct = ship.get("hull_integrity_pct")
+        if pct is None:
+            continue
+        if pct <= threshold:
+            name = ship.get("ship_name", "unknown")
+            trips.append(
+                BreakerTrip(
+                    type="hull_integrity_breach",
+                    value=pct,
+                    threshold=threshold,
+                    action="hull-integrity",
+                    message=(
+                        f"{name} hull integrity {pct}% <= threshold {threshold}%. "
+                        f"See damage-control/hull-integrity.md."
+                    ),
+                    context={"ship_name": name},
+                )
+            )
+    return trips
+
+
+def _check_budget_alarm(
+    fleet_status: dict[str, Any],
+    sailing_orders: dict[str, Any] | None,
+    config: dict[str, Any],
+) -> list[BreakerTrip]:
+    """Trip when tokens are burning faster than tasks are completing."""
+    if not sailing_orders:
+        return []
+    token_limit = (sailing_orders.get("budget") or {}).get("token_limit")
+    if not token_limit or token_limit <= 0:
+        return []
+
+    budget = fleet_status.get("budget") or {}
+    tokens_spent = budget.get("tokens_spent", 0)
+    progress = fleet_status.get("progress") or {}
+    completed = progress.get("completed", 0)
+    total = progress.get("total", 0)
+    if total <= 0:
+        return []
+
+    spent_ratio = tokens_spent / token_limit
+    completion_ratio = completed / total
+
+    alarm_ratio = config["budget_alarm_ratio"]
+    completion_threshold = config["budget_alarm_completion_ratio"]
+
+    if spent_ratio >= alarm_ratio and completion_ratio < completion_threshold:
+        return [
+            BreakerTrip(
+                type="budget_alarm",
+                value={
+                    "spent_ratio": round(spent_ratio, 3),
+                    "completion_ratio": round(completion_ratio, 3),
+                },
+                threshold={
+                    "spent_ratio": alarm_ratio,
+                    "completion_ratio": completion_threshold,
+                },
+                action="admiral-review",
+                message=(
+                    f"Budget alarm: {spent_ratio:.0%} of tokens spent with only "
+                    f"{completion_ratio:.0%} of tasks complete. Elevate to Station 2 "
+                    f"and review scope."
+                ),
+                context={
+                    "tokens_spent": tokens_spent,
+                    "token_limit": token_limit,
+                    "completed": completed,
+                    "total": total,
+                },
+            )
+        ]
+    return []
+
+
+def _check_cost_per_task_overrun(
+    events: list[dict[str, Any]], config: dict[str, Any]
+) -> list[BreakerTrip]:
+    """Trip when the latest burn-rate-per-task is N times the rolling median."""
+    min_history = config["cost_per_task_min_history"]
+    multiplier = config["cost_per_task_multiplier"]
+
+    checkpoints = [e for e in events if e.get("type") == "checkpoint"]
+    if len(checkpoints) < min_history:
+        return []
+
+    rates: list[float] = []
+    for cp in checkpoints:
+        data = cp.get("data") or {}
+        budget = data.get("budget") or {}
+        progress = data.get("progress") or {}
+        completed = progress.get("completed", 0)
+        burn = budget.get("burn_rate_per_checkpoint", 0) or 0
+        if completed <= 0 or burn <= 0:
+            continue
+        rates.append(burn / completed)
+
+    if len(rates) < min_history:
+        return []
+
+    latest = rates[-1]
+    baseline = statistics.median(rates[:-1])
+    if baseline <= 0:
+        return []
+
+    if latest >= multiplier * baseline:
+        return [
+            BreakerTrip(
+                type="cost_per_task_overrun",
+                value=round(latest, 2),
+                threshold=round(multiplier * baseline, 2),
+                action="crew-overrun",
+                message=(
+                    f"Cost per task {latest:.0f} tokens/task is >= "
+                    f"{multiplier:.1f}x baseline ({baseline:.0f}). "
+                    f"See damage-control/crew-overrun.md."
+                ),
+                context={"baseline_median": round(baseline, 2)},
+            )
+        ]
+    return []
+
+
+def _check_consecutive_failures(
+    events: list[dict[str, Any]], config: dict[str, Any]
+) -> list[BreakerTrip]:
+    """Trip on N consecutive blockers without resolution."""
+    threshold = config["consecutive_failures"]
+    run_length = 0
+    for event in events:
+        etype = event.get("type")
+        if etype == "blocker_raised":
+            run_length += 1
+        elif etype == "blocker_resolved":
+            run_length = 0
+    if run_length >= threshold:
+        return [
+            BreakerTrip(
+                type="consecutive_failures",
+                value=run_length,
+                threshold=threshold,
+                action="scuttle-and-reform",
+                message=(
+                    f"{run_length} unresolved blockers in a row (>= {threshold}). "
+                    f"Consider scuttle-and-reform. "
+                    f"See damage-control/scuttle-and-reform.md."
+                ),
+                context={},
+            )
+        ]
+    return []
+
+
+def _check_time_limit(
+    fleet_status: dict[str, Any],
+    sailing_orders: dict[str, Any] | None,
+    config: dict[str, Any],
+    now_iso: str,
+) -> list[BreakerTrip]:
+    """Trip when elapsed mission minutes >= configured time_limit_minutes."""
+    if not sailing_orders:
+        return []
+    budget = sailing_orders.get("budget") or {}
+    limit = budget.get("time_limit_minutes")
+    if not limit or limit <= 0:
+        return []
+
+    started_at = (fleet_status.get("mission") or {}).get("started_at")
+    if not started_at:
+        return []
+
+    try:
+        start_dt = datetime.strptime(started_at, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+        now_dt = datetime.strptime(now_iso, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except (ValueError, TypeError):
+        return []
+
+    elapsed_minutes = (now_dt - start_dt).total_seconds() / 60.0
+    grace = config.get("time_limit_grace_minutes", 0) or 0
+    if elapsed_minutes >= (limit + grace):
+        return [
+            BreakerTrip(
+                type="time_limit",
+                value=round(elapsed_minutes, 1),
+                threshold=limit,
+                action="admiral-review",
+                message=(
+                    f"Mission duration {elapsed_minutes:.0f} min >= "
+                    f"time limit {limit} min. Review scope or declare stand-down."
+                ),
+                context={"grace_minutes": grace},
+            )
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Idle timeout — evaluated by the TeammateIdle hook (not at checkpoint)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_idle_timeout(
+    mission_dir: Path,
+    ship_name: str,
+    now_iso: str,
+    config: dict[str, Any] | None = None,
+) -> BreakerTrip | None:
+    """Check whether *ship_name* has been idle longer than the configured threshold.
+
+    Reads and writes ``mission_dir/idle-tracker.json`` to record the first-idle
+    timestamp per ship. Returns a BreakerTrip if the threshold is crossed,
+    otherwise None. The caller is responsible for surfacing the advisory.
+    """
+    cfg = config or DEFAULT_THRESHOLDS
+    timeout_minutes = cfg.get("idle_timeout_minutes", 10)
+
+    tracker_path = mission_dir / "idle-tracker.json"
+    tracker: dict[str, str] = {}
+    if tracker_path.exists():
+        try:
+            import json
+
+            tracker = json.loads(tracker_path.read_text(encoding="utf-8"))
+            if not isinstance(tracker, dict):
+                tracker = {}
+        except (OSError, ValueError):
+            tracker = {}
+
+    first_seen = tracker.get(ship_name)
+    if first_seen is None:
+        # First idle event for this ship — record and return.
+        tracker[ship_name] = now_iso
+        _write_tracker(tracker_path, tracker)
+        return None
+
+    try:
+        start_dt = datetime.strptime(first_seen, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+        now_dt = datetime.strptime(now_iso, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except (ValueError, TypeError):
+        # Bad tracker state — reset.
+        tracker[ship_name] = now_iso
+        _write_tracker(tracker_path, tracker)
+        return None
+
+    elapsed_minutes = (now_dt - start_dt).total_seconds() / 60.0
+    if elapsed_minutes < timeout_minutes:
+        return None
+
+    return BreakerTrip(
+        type="idle_timeout",
+        value=round(elapsed_minutes, 1),
+        threshold=timeout_minutes,
+        action="man-overboard",
+        message=(
+            f"{ship_name} idle for {elapsed_minutes:.0f} min "
+            f"(threshold {timeout_minutes} min). "
+            f"Consider man-overboard. See damage-control/man-overboard.md."
+        ),
+        context={"ship_name": ship_name, "first_idle_at": first_seen},
+    )
+
+
+def clear_idle_tracker(mission_dir: Path, ship_name: str | None = None) -> None:
+    """Remove tracker entries. If *ship_name* is None, clear all entries."""
+    tracker_path = mission_dir / "idle-tracker.json"
+    if not tracker_path.exists():
+        return
+
+    import json
+
+    try:
+        tracker = json.loads(tracker_path.read_text(encoding="utf-8"))
+        if not isinstance(tracker, dict):
+            return
+    except (OSError, ValueError):
+        return
+
+    if ship_name is None:
+        tracker = {}
+    else:
+        tracker.pop(ship_name, None)
+
+    _write_tracker(tracker_path, tracker)
+
+
+def _write_tracker(tracker_path: Path, tracker: dict[str, str]) -> None:
+    """Write the idle tracker atomically (best effort — non-fatal on error)."""
+    import json
+
+    try:
+        tracker_path.parent.mkdir(parents=True, exist_ok=True)
+        tracker_path.write_text(
+            json.dumps(tracker, indent=2) + "\n", encoding="utf-8"
+        )
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fleet-status augmentation
+# ---------------------------------------------------------------------------
+
+
+def compute_budget_metrics(
+    tokens_spent: int,
+    tokens_remaining: int | None,
+    completed: int,
+    total: int,
+) -> dict[str, Any]:
+    """Compute burn_rate_per_task and projected_budget_at_completion.
+
+    * ``burn_rate_per_task`` is integer tokens per completed task, or None
+      when no tasks are yet completed.
+    * ``projected_budget_at_completion`` is a simple linear extrapolation:
+      ``burn_rate_per_task * total``. None when burn rate is unknown.
+    """
+    if completed <= 0 or tokens_spent <= 0:
+        return {
+            "burn_rate_per_task": None,
+            "projected_budget_at_completion": None,
+        }
+    burn_rate = tokens_spent / completed
+    projected = None
+    if total > 0:
+        projected = int(round(burn_rate * total))
+    return {
+        "burn_rate_per_task": int(round(burn_rate)),
+        "projected_budget_at_completion": projected,
+    }
+
+
+def format_alarm_line(trip: BreakerTrip) -> str:
+    """Format a single trip for display at the admiral's quarterdeck."""
+    return f"[CIRCUIT BREAKER: {trip.type}] {trip.message}"

--- a/skills/nelson/scripts/nelson_data_lifecycle.py
+++ b/skills/nelson/scripts/nelson_data_lifecycle.py
@@ -17,6 +17,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from nelson_circuit_breakers import (
+    BreakerTrip,
+    compute_budget_metrics,
+    evaluate as evaluate_circuit_breakers,
+    format_alarm_line,
+    load_config as load_circuit_breaker_config,
+)
 from nelson_data_memory import _update_patterns_store, _update_standing_order_stats
 from nelson_data_utils import (
     JSON_INDENT,
@@ -58,6 +65,7 @@ def _do_init(
     out_of_scope: list[str] | None = None,
     stop_criteria: list[str] | None = None,
     handoff_artifacts: list[str] | None = None,
+    circuit_breakers: dict[str, Any] | None = None,
 ) -> Path:
     """Create mission directory and write initial JSON files.  Returns the path."""
     base = Path(".nelson") / "missions" / _mission_dir_stamp()
@@ -78,6 +86,7 @@ def _do_init(
         "out_of_scope": list(out_of_scope or []),
         "stop_criteria": list(stop_criteria or []),
         "handoff_artifacts": list(handoff_artifacts or []),
+        "circuit_breakers": dict(circuit_breakers) if circuit_breakers else {},
         "created_at": _now_iso(),
     }
 
@@ -628,6 +637,13 @@ def cmd_checkpoint(args: argparse.Namespace) -> None:
         old_fs = _read_json(fs_path)
         existing_phase = old_fs.get("mission", {}).get("phase")
 
+    budget_metrics = compute_budget_metrics(
+        tokens_spent=args.tokens_spent,
+        tokens_remaining=args.tokens_remaining,
+        completed=args.completed,
+        total=total,
+    )
+
     fleet_status = {
         "version": 1,
         "mission": {
@@ -649,6 +665,10 @@ def cmd_checkpoint(args: argparse.Namespace) -> None:
             "tokens_remaining": args.tokens_remaining,
             "pct_consumed": pct_consumed,
             "burn_rate_per_checkpoint": burn_rate,
+            "burn_rate_per_task": budget_metrics["burn_rate_per_task"],
+            "projected_budget_at_completion": budget_metrics[
+                "projected_budget_at_completion"
+            ],
         },
         "squadron": squadron_status,
         "blockers": [],
@@ -667,6 +687,27 @@ def cmd_checkpoint(args: argparse.Namespace) -> None:
 
     _write_json(fs_path, fleet_status)
 
+    # Evaluate automated circuit breakers against the freshly-written state.
+    # Trips are advisory — surface them to the admiral via stdout and append
+    # structured events so post-mission analysis can see what fired.
+    sailing_orders_for_breakers = _read_json_optional(so_path) if so_path.exists() else None
+    trips = evaluate_circuit_breakers(
+        fleet_status=fleet_status,
+        sailing_orders=sailing_orders_for_breakers,
+        mission_log_events=events + [checkpoint_event],
+        now_iso=_now_iso(),
+    )
+    for trip in trips:
+        _append_event(
+            mission_dir,
+            {
+                "type": "circuit_breaker_tripped",
+                "checkpoint": checkpoint_num,
+                "timestamp": _now_iso(),
+                "data": trip.to_event_data(),
+            },
+        )
+
     hull_summary = (
         f"{args.hull_green}G {args.hull_amber}A {args.hull_red}R {args.hull_critical}C"
     )
@@ -677,6 +718,8 @@ def cmd_checkpoint(args: argparse.Namespace) -> None:
         f"Hull: {hull_summary} | "
         f"Blockers: {args.blocked}"
     )
+    for trip in trips:
+        print(format_alarm_line(trip))
 
 
 # ---------------------------------------------------------------------------

--- a/skills/nelson/scripts/nelson_data_utils.py
+++ b/skills/nelson/scripts/nelson_data_utils.py
@@ -46,6 +46,7 @@ VALID_EVENT_TYPES = frozenset(
         "phase_transition",
         "phase_override",
         "permission_granted",
+        "circuit_breaker_tripped",
     }
 )
 

--- a/skills/nelson/scripts/test_nelson_circuit_breakers.py
+++ b/skills/nelson/scripts/test_nelson_circuit_breakers.py
@@ -1,0 +1,499 @@
+"""Tests for nelson_circuit_breakers and checkpoint integration."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from conftest import (
+    add_squadron,
+    add_task,
+    init_mission,
+    read_json,
+    run,
+)
+
+from nelson_circuit_breakers import (
+    BreakerTrip,
+    DEFAULT_THRESHOLDS,
+    clear_idle_tracker,
+    compute_budget_metrics,
+    evaluate,
+    evaluate_idle_timeout,
+    load_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now_iso() -> str:
+    return _iso(datetime.now(timezone.utc))
+
+
+def _fleet_status(
+    *,
+    tokens_spent: int = 0,
+    completed: int = 0,
+    total: int = 4,
+    squadron: list[dict] | None = None,
+    started_at: str | None = None,
+) -> dict:
+    return {
+        "version": 1,
+        "mission": {
+            "outcome": "Test",
+            "status": "underway",
+            "phase": "ACTION_STATIONS",
+            "started_at": started_at or _now_iso(),
+            "checkpoint_number": 1,
+        },
+        "progress": {
+            "pending": max(total - completed, 0),
+            "in_progress": 0,
+            "completed": completed,
+            "blocked": 0,
+            "total": total,
+        },
+        "budget": {
+            "tokens_spent": tokens_spent,
+            "tokens_remaining": 0,
+            "pct_consumed": 0.0,
+            "burn_rate_per_checkpoint": 0,
+        },
+        "squadron": squadron or [],
+    }
+
+
+def _sailing_orders(
+    token_limit: int | None = 100_000,
+    time_limit_minutes: int | None = None,
+    circuit_breakers: dict | None = None,
+) -> dict:
+    return {
+        "version": 1,
+        "outcome": "Test",
+        "budget": {
+            "token_limit": token_limit,
+            "time_limit_minutes": time_limit_minutes,
+        },
+        "circuit_breakers": circuit_breakers or {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_defaults_when_no_sailing_orders(self) -> None:
+        config = load_config(None)
+        assert config == DEFAULT_THRESHOLDS
+        # Returned object must be an independent copy
+        config["enabled"] = False
+        assert DEFAULT_THRESHOLDS["enabled"] is True
+
+    def test_user_overrides_applied(self) -> None:
+        so = _sailing_orders(
+            circuit_breakers={
+                "hull_integrity_threshold": 50,
+                "budget_alarm_ratio": 0.9,
+            }
+        )
+        config = load_config(so)
+        assert config["hull_integrity_threshold"] == 50
+        assert config["budget_alarm_ratio"] == 0.9
+        # Unmodified keys retain defaults
+        assert config["idle_timeout_minutes"] == DEFAULT_THRESHOLDS["idle_timeout_minutes"]
+
+    def test_unknown_keys_dropped(self) -> None:
+        so = _sailing_orders(circuit_breakers={"not_a_real_key": 999})
+        config = load_config(so)
+        assert "not_a_real_key" not in config
+
+
+# ---------------------------------------------------------------------------
+# Hull integrity
+# ---------------------------------------------------------------------------
+
+
+class TestHullIntegrityBreaker:
+    def test_clean_state_no_trips(self) -> None:
+        fs = _fleet_status(
+            squadron=[{"ship_name": "HMS Argyll", "hull_integrity_pct": 90}]
+        )
+        trips = evaluate(fs, _sailing_orders(), [], _now_iso())
+        assert trips == []
+
+    def test_equals_threshold_trips(self) -> None:
+        fs = _fleet_status(
+            squadron=[{"ship_name": "HMS Argyll", "hull_integrity_pct": 80}]
+        )
+        trips = evaluate(fs, _sailing_orders(), [], _now_iso())
+        assert len(trips) == 1
+        assert trips[0].type == "hull_integrity_breach"
+        assert trips[0].action == "hull-integrity"
+        assert "HMS Argyll" in trips[0].message
+
+    def test_below_threshold_trips(self) -> None:
+        fs = _fleet_status(
+            squadron=[
+                {"ship_name": "HMS Argyll", "hull_integrity_pct": 95},
+                {"ship_name": "HMS Kent", "hull_integrity_pct": 45},
+            ]
+        )
+        trips = evaluate(fs, _sailing_orders(), [], _now_iso())
+        breach = [t for t in trips if t.type == "hull_integrity_breach"]
+        assert len(breach) == 1
+        assert breach[0].context["ship_name"] == "HMS Kent"
+
+    def test_missing_pct_skipped(self) -> None:
+        fs = _fleet_status(
+            squadron=[{"ship_name": "HMS Argyll", "hull_integrity_pct": None}]
+        )
+        trips = evaluate(fs, _sailing_orders(), [], _now_iso())
+        assert trips == []
+
+
+# ---------------------------------------------------------------------------
+# Budget alarm
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetAlarmBreaker:
+    def test_clean_state_no_trips(self) -> None:
+        fs = _fleet_status(tokens_spent=50_000, completed=3, total=4)
+        trips = evaluate(fs, _sailing_orders(token_limit=100_000), [], _now_iso())
+        assert not any(t.type == "budget_alarm" for t in trips)
+
+    def test_over_spent_ratio_but_tasks_ahead_no_trip(self) -> None:
+        # 70% spent but 75% complete — fine
+        fs = _fleet_status(tokens_spent=70_000, completed=3, total=4)
+        trips = evaluate(fs, _sailing_orders(token_limit=100_000), [], _now_iso())
+        assert not any(t.type == "budget_alarm" for t in trips)
+
+    def test_alarm_when_spent_ahead_of_completion(self) -> None:
+        # 70% spent, 25% complete — tripwire
+        fs = _fleet_status(tokens_spent=70_000, completed=1, total=4)
+        trips = evaluate(fs, _sailing_orders(token_limit=100_000), [], _now_iso())
+        alarms = [t for t in trips if t.type == "budget_alarm"]
+        assert len(alarms) == 1
+        assert alarms[0].action == "admiral-review"
+        assert alarms[0].context["tokens_spent"] == 70_000
+
+    def test_no_token_limit_skipped(self) -> None:
+        fs = _fleet_status(tokens_spent=70_000, completed=1, total=4)
+        trips = evaluate(fs, _sailing_orders(token_limit=None), [], _now_iso())
+        assert not any(t.type == "budget_alarm" for t in trips)
+
+    def test_zero_total_skipped(self) -> None:
+        fs = _fleet_status(tokens_spent=70_000, completed=0, total=0)
+        trips = evaluate(fs, _sailing_orders(token_limit=100_000), [], _now_iso())
+        assert not any(t.type == "budget_alarm" for t in trips)
+
+
+# ---------------------------------------------------------------------------
+# Cost per task overrun
+# ---------------------------------------------------------------------------
+
+
+def _cp(completed: int, burn: int) -> dict:
+    return {
+        "type": "checkpoint",
+        "data": {
+            "progress": {"completed": completed},
+            "budget": {"burn_rate_per_checkpoint": burn},
+        },
+    }
+
+
+class TestCostPerTaskOverrun:
+    def test_insufficient_history_no_trip(self) -> None:
+        events = [_cp(1, 5000), _cp(2, 5000)]  # only 2 < min_history 3
+        trips = evaluate(_fleet_status(), _sailing_orders(), events, _now_iso())
+        assert not any(t.type == "cost_per_task_overrun" for t in trips)
+
+    def test_stable_burn_no_trip(self) -> None:
+        events = [_cp(1, 5000), _cp(2, 5000), _cp(3, 5000)]
+        trips = evaluate(_fleet_status(), _sailing_orders(), events, _now_iso())
+        assert not any(t.type == "cost_per_task_overrun" for t in trips)
+
+    def test_spike_trips(self) -> None:
+        # First three checkpoints: ~5000 tokens/task.
+        # Fourth: 60000 tokens/task — clearly a spike.
+        events = [
+            _cp(1, 5000),  # rate 5000
+            _cp(2, 5000),  # rate 2500
+            _cp(3, 5000),  # rate 1666
+            _cp(1, 60000),  # rate 60000 — > 3x baseline median 2500
+        ]
+        trips = evaluate(_fleet_status(), _sailing_orders(), events, _now_iso())
+        overrun = [t for t in trips if t.type == "cost_per_task_overrun"]
+        assert len(overrun) == 1
+        assert overrun[0].action == "crew-overrun"
+
+
+# ---------------------------------------------------------------------------
+# Consecutive failures
+# ---------------------------------------------------------------------------
+
+
+class TestConsecutiveFailures:
+    def test_zero_blockers_no_trip(self) -> None:
+        trips = evaluate(_fleet_status(), _sailing_orders(), [], _now_iso())
+        assert not any(t.type == "consecutive_failures" for t in trips)
+
+    def test_single_blocker_no_trip(self) -> None:
+        events = [{"type": "blocker_raised"}]
+        trips = evaluate(_fleet_status(), _sailing_orders(), events, _now_iso())
+        assert not any(t.type == "consecutive_failures" for t in trips)
+
+    def test_two_blockers_trips(self) -> None:
+        events = [{"type": "blocker_raised"}, {"type": "blocker_raised"}]
+        trips = evaluate(_fleet_status(), _sailing_orders(), events, _now_iso())
+        failures = [t for t in trips if t.type == "consecutive_failures"]
+        assert len(failures) == 1
+        assert failures[0].action == "scuttle-and-reform"
+
+    def test_resolution_resets_counter(self) -> None:
+        events = [
+            {"type": "blocker_raised"},
+            {"type": "blocker_resolved"},
+            {"type": "blocker_raised"},
+        ]
+        trips = evaluate(_fleet_status(), _sailing_orders(), events, _now_iso())
+        assert not any(t.type == "consecutive_failures" for t in trips)
+
+
+# ---------------------------------------------------------------------------
+# Time limit
+# ---------------------------------------------------------------------------
+
+
+class TestTimeLimit:
+    def test_within_limit_no_trip(self) -> None:
+        started = _iso(datetime.now(timezone.utc) - timedelta(minutes=5))
+        fs = _fleet_status(started_at=started)
+        trips = evaluate(fs, _sailing_orders(time_limit_minutes=60), [], _now_iso())
+        assert not any(t.type == "time_limit" for t in trips)
+
+    def test_over_limit_trips(self) -> None:
+        started = _iso(datetime.now(timezone.utc) - timedelta(minutes=120))
+        fs = _fleet_status(started_at=started)
+        trips = evaluate(fs, _sailing_orders(time_limit_minutes=60), [], _now_iso())
+        time_trips = [t for t in trips if t.type == "time_limit"]
+        assert len(time_trips) == 1
+        assert time_trips[0].threshold == 60
+
+
+# ---------------------------------------------------------------------------
+# Disabled
+# ---------------------------------------------------------------------------
+
+
+class TestDisabled:
+    def test_disabled_skips_all_checks(self) -> None:
+        fs = _fleet_status(
+            tokens_spent=90_000,
+            completed=0,
+            total=4,
+            squadron=[{"ship_name": "HMS Argyll", "hull_integrity_pct": 20}],
+        )
+        so = _sailing_orders(circuit_breakers={"enabled": False})
+        events = [{"type": "blocker_raised"}, {"type": "blocker_raised"}]
+        trips = evaluate(fs, so, events, _now_iso())
+        assert trips == []
+
+
+# ---------------------------------------------------------------------------
+# Idle timeout
+# ---------------------------------------------------------------------------
+
+
+class TestIdleTimeout:
+    def test_first_idle_records_no_trip(self, tmp_path: Path) -> None:
+        trip = evaluate_idle_timeout(tmp_path, "HMS Argyll", _now_iso())
+        assert trip is None
+        tracker = json.loads((tmp_path / "idle-tracker.json").read_text())
+        assert "HMS Argyll" in tracker
+
+    def test_under_threshold_no_trip(self, tmp_path: Path) -> None:
+        first = datetime.now(timezone.utc)
+        evaluate_idle_timeout(tmp_path, "HMS Argyll", _iso(first))
+        later = _iso(first + timedelta(minutes=5))
+        trip = evaluate_idle_timeout(tmp_path, "HMS Argyll", later)
+        assert trip is None
+
+    def test_over_threshold_trips(self, tmp_path: Path) -> None:
+        first = datetime.now(timezone.utc)
+        evaluate_idle_timeout(tmp_path, "HMS Argyll", _iso(first))
+        later = _iso(first + timedelta(minutes=15))
+        trip = evaluate_idle_timeout(tmp_path, "HMS Argyll", later)
+        assert trip is not None
+        assert trip.type == "idle_timeout"
+        assert trip.action == "man-overboard"
+        assert trip.context["ship_name"] == "HMS Argyll"
+
+    def test_custom_threshold(self, tmp_path: Path) -> None:
+        first = datetime.now(timezone.utc)
+        config = dict(DEFAULT_THRESHOLDS)
+        config["idle_timeout_minutes"] = 1
+        evaluate_idle_timeout(tmp_path, "HMS Argyll", _iso(first), config)
+        later = _iso(first + timedelta(minutes=2))
+        trip = evaluate_idle_timeout(tmp_path, "HMS Argyll", later, config)
+        assert trip is not None
+
+    def test_clear_removes_entry(self, tmp_path: Path) -> None:
+        evaluate_idle_timeout(tmp_path, "HMS Argyll", _now_iso())
+        clear_idle_tracker(tmp_path, "HMS Argyll")
+        tracker = json.loads((tmp_path / "idle-tracker.json").read_text())
+        assert "HMS Argyll" not in tracker
+
+
+# ---------------------------------------------------------------------------
+# Budget metric computation
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetMetrics:
+    def test_no_progress_returns_none(self) -> None:
+        metrics = compute_budget_metrics(
+            tokens_spent=5000, tokens_remaining=None, completed=0, total=4
+        )
+        assert metrics["burn_rate_per_task"] is None
+        assert metrics["projected_budget_at_completion"] is None
+
+    def test_linear_projection(self) -> None:
+        metrics = compute_budget_metrics(
+            tokens_spent=10_000, tokens_remaining=None, completed=2, total=8
+        )
+        assert metrics["burn_rate_per_task"] == 5000
+        assert metrics["projected_budget_at_completion"] == 40_000
+
+    def test_total_zero_projection_none(self) -> None:
+        metrics = compute_budget_metrics(
+            tokens_spent=10_000, tokens_remaining=None, completed=2, total=0
+        )
+        assert metrics["burn_rate_per_task"] == 5000
+        assert metrics["projected_budget_at_completion"] is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end checkpoint integration
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointIntegration:
+    def test_sailing_orders_persists_circuit_breakers_key(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        sailing = read_json(mission_dir / "sailing-orders.json")
+        assert "circuit_breakers" in sailing
+        assert sailing["circuit_breakers"] == {}
+
+    def test_checkpoint_writes_burn_rate_per_task(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        add_task(mission_dir)
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "0",
+            "--in-progress", "0",
+            "--completed", "2",
+            "--blocked", "0",
+            "--tokens-spent", "20000",
+            "--tokens-remaining", "80000",
+            "--hull-green", "1",
+            "--hull-amber", "0",
+            "--hull-red", "0",
+            "--hull-critical", "0",
+            "--decision", "continue",
+            "--rationale", "All good",
+        )
+        fs = read_json(mission_dir / "fleet-status.json")
+        assert fs["budget"]["burn_rate_per_task"] == 10000
+        # total comes from pending+in_progress+completed = 2
+        assert fs["budget"]["projected_budget_at_completion"] == 20000
+
+    def test_checkpoint_emits_circuit_breaker_event_on_budget_alarm(
+        self, tmp_path: Path
+    ) -> None:
+        mission_dir = init_mission(tmp_path, **{"--token-budget": "100000"})
+        add_squadron(
+            mission_dir,
+            captains=[
+                "HMS Argyll:frigate:sonnet:1",
+                "HMS Kent:frigate:sonnet:2",
+                "HMS Warspite:destroyer:sonnet:3",
+                "HMS Defiance:frigate:sonnet:4",
+            ],
+        )
+        for i, owner in enumerate(
+            ["HMS Argyll", "HMS Kent", "HMS Warspite", "HMS Defiance"]
+        ):
+            add_task(mission_dir, task_id=i + 1, owner=owner)
+        run("plan-approved", "--mission-dir", str(mission_dir))
+
+        # 80% spent but 25% complete — trips budget alarm.
+        result = run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "3",
+            "--in-progress", "0",
+            "--completed", "1",
+            "--blocked", "0",
+            "--tokens-spent", "80000",
+            "--tokens-remaining", "20000",
+            "--hull-green", "4",
+            "--hull-amber", "0",
+            "--hull-red", "0",
+            "--hull-critical", "0",
+            "--decision", "continue",
+            "--rationale", "Pressing on",
+        )
+        assert "CIRCUIT BREAKER: budget_alarm" in result.stdout
+
+        log = read_json(mission_dir / "mission-log.json")
+        trips = [
+            e for e in log["events"] if e.get("type") == "circuit_breaker_tripped"
+        ]
+        assert len(trips) >= 1
+        assert any(
+            t["data"]["type"] == "budget_alarm" for t in trips
+        )
+
+    def test_clean_checkpoint_no_breakers(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path, **{"--token-budget": "100000"})
+        add_squadron(mission_dir)
+        add_task(mission_dir)
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        result = run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "0",
+            "--in-progress", "0",
+            "--completed", "1",
+            "--blocked", "0",
+            "--tokens-spent", "10000",
+            "--tokens-remaining", "90000",
+            "--hull-green", "1",
+            "--hull-amber", "0",
+            "--hull-red", "0",
+            "--hull-critical", "0",
+            "--decision", "continue",
+            "--rationale", "All good",
+        )
+        assert "CIRCUIT BREAKER" not in result.stdout
+        log = read_json(mission_dir / "mission-log.json")
+        assert not any(
+            e.get("type") == "circuit_breaker_tripped" for e in log["events"]
+        )


### PR DESCRIPTION
Add advisory circuit breakers that evaluate thresholds at each quarterdeck
checkpoint and on TeammateIdle, log structured circuit_breaker_tripped
events, and recommend damage control procedures. Configurable via
sailing-orders.json circuit_breakers key. Advisory only — no auto-abort.

https://claude.ai/code/session_01MERUswHwBPxkcbYQj87oKV