### PR TITLE
fix: replace {skill-dir} with ${CLAUDE_PLUGIN_ROOT} and simplify auto-exec block (#99)

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -8,7 +8,7 @@ paths: [".nelson/**"]
 # Nelson
 
 ```!
-python3 "{skill-dir}/scripts/nelson-data.py" status --mission-dir "$(ls -td .nelson/missions/*/ 2>/dev/null | head -1)" || echo "No active missions"
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/nelson-data.py" status
 ```
 
 Execute this workflow for the user's mission.

--- a/skills/nelson/scripts/nelson_data_lifecycle.py
+++ b/skills/nelson/scripts/nelson_data_lifecycle.py
@@ -855,9 +855,22 @@ def cmd_stand_down(args: argparse.Namespace) -> None:
 
 def cmd_status(args: argparse.Namespace) -> None:
     """Print current fleet status from fleet-status.json (read-only)."""
-    raw = getattr(args, "mission_dir", None)
-    if not raw:
-        return  # silent no-op
+    raw = getattr(args, "mission_dir", None) or ""
+    if not raw.strip():
+        # Auto-detect latest mission directory when none provided.
+        missions_root = Path(".nelson/missions")
+        if not missions_root.is_dir():
+            print("No active missions")
+            return
+        candidates = sorted(
+            (d for d in missions_root.iterdir() if d.is_dir()),
+            key=lambda d: d.stat().st_mtime,
+            reverse=True,
+        )
+        if not candidates:
+            print("No active missions")
+            return
+        raw = str(candidates[0])
     mission_dir = Path(raw)
     fs_path = mission_dir / "fleet-status.json"
     if not fs_path.exists():

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -443,6 +443,38 @@ class TestStatus:
         # Silent no-op — no output, no error
         assert result.stdout.strip() == ""
 
+    def test_status_auto_detects_latest_mission(self, tmp_path: Path) -> None:
+        """Status without --mission-dir auto-detects the latest mission."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        run(
+            "checkpoint",
+            "--mission-dir", str(mission_dir),
+            "--pending", "1", "--in-progress", "1", "--completed", "1", "--blocked", "0",
+            "--tokens-spent", "30000", "--tokens-remaining", "70000",
+            "--hull-green", "2", "--hull-amber", "0", "--hull-red", "0", "--hull-critical", "0",
+            "--decision", "continue", "--rationale", "Test",
+        )
+        import os
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = run("status", "--mission-dir", "")
+            assert "Status:" in result.stdout or "nelson-data" in result.stdout
+        finally:
+            os.chdir(old_cwd)
+
+    def test_status_no_missions_dir_prints_message(self, tmp_path: Path) -> None:
+        """Status without --mission-dir and no .nelson/missions/ prints message."""
+        import os
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = run("status", "--mission-dir", "")
+            assert "No active missions" in result.stdout
+        finally:
+            os.chdir(old_cwd)
+
 
 # ---------------------------------------------------------------------------
 # Form (composite command)


### PR DESCRIPTION
The ```! block in SKILL.md used {skill-dir}, a placeholder that doesn't
exist in Claude Code, and complex shell syntax (subshells, pipes, globs)
that the permission parser cannot handle. Replace with
${CLAUDE_PLUGIN_ROOT} (the documented env var) and move mission
auto-detection into cmd_status so the shell command is trivially simple.

https://claude.ai/code/session_01HQ63YK6SE5m91kMkaTY8nx