### PR TITLE
fix: correct auto-exec script path for issue #99

### DIFF
--- a/scripts/check-references.sh
+++ b/scripts/check-references.sh
@@ -102,6 +102,30 @@ for ref_file in "$REF_DIR"/*.md; do
   fi
 done
 
+# ---------- 6. Auto-exec script path ----------
+# The ```! block in SKILL.md must reference a script that actually exists.
+# Regression guard for issue #99: {skill-dir} → ${CLAUDE_PLUGIN_ROOT} path fix.
+echo "Checking auto-exec script paths..."
+while IFS= read -r script_path; do
+  # Strip the ${CLAUDE_PLUGIN_ROOT}/ prefix to get repo-relative path
+  rel_path="${script_path#\$\{CLAUDE_PLUGIN_ROOT\}/}"
+  if [ ! -f "$rel_path" ]; then
+    error "SKILL.md auto-exec references '$script_path' but '$rel_path' does not exist"
+  fi
+done < <(sed -n '/^```!/,/^```$/p' "$SKILL_DIR/SKILL.md" \
+  | grep -oE '\$\{CLAUDE_PLUGIN_ROOT\}/[^ "]+' \
+  | sort -u)
+
+# ---------- 7. No {skill-dir} placeholder ----------
+# {skill-dir} is not a valid Claude Code variable. Use ${CLAUDE_PLUGIN_ROOT}.
+echo "Checking for invalid {skill-dir} placeholders..."
+for file in "$SKILL_DIR/SKILL.md" hooks/hooks.json; do
+  [ -f "$file" ] || continue
+  if grep -q '{skill-dir}' "$file"; then
+    error "$file contains invalid {skill-dir} placeholder (use \${CLAUDE_PLUGIN_ROOT})"
+  fi
+done
+
 # ---------- Summary ----------
 if [ "$errors" -gt 0 ]; then
   echo ""

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -8,7 +8,7 @@ paths: [".nelson/**"]
 # Nelson
 
 ```!
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/nelson-data.py" status
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/nelson/scripts/nelson-data.py" status
 ```
 
 Execute this workflow for the user's mission.


### PR DESCRIPTION
## Summary

- **Root cause**: PR #100 replaced `{skill-dir}` with `${CLAUDE_PLUGIN_ROOT}` but didn't account for the script being nested at `skills/nelson/scripts/nelson-data.py` rather than `scripts/nelson-data.py`
- **Fix**: Corrects path in SKILL.md to `${CLAUDE_PLUGIN_ROOT}/skills/nelson/scripts/nelson-data.py`
- **Regression guard**: Adds two checks to `check-references.sh`:
  1. Validates all auto-exec `${CLAUDE_PLUGIN_ROOT}/...` paths resolve to real files
  2. Rejects any `{skill-dir}` placeholders in SKILL.md or hooks.json

Closes #99

## Test plan

- [x] `bash scripts/check-references.sh` passes with the fix
- [x] Verified the check catches the old broken path (`scripts/nelson-data.py` → MISSING)
- [x] All 71 existing tests pass (`pytest skills/nelson/scripts/test_nelson_data.py`)