### PR TITLE
feat(nelson): align skill with Claude Code Agent Teams capabilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,11 @@ skills/nelson/
       damage-report.md        — JSON template for hull integrity damage reports
       estimate.md             — Estimate skeleton (~25-line H2 scaffold)
       turnover-brief.md       — Handover brief for relief on station
+    background-patterns.md  — Background-agent and Monitor coordination patterns
     commendations.md        — Recognition signals & graduated correction
     crew-roles.md           — Crew role definitions, ship names & sizing rules
     damage-control/         — One file per procedure, loaded on demand
+      agent-team-spawn-broken.md — Recovery for #40270 broken Agent(team_name=...)
       comms-failure.md        — Agent team infrastructure failure recovery
       crew-overrun.md         — Ship crew consuming disproportionate resources
       escalation.md           — Issue exceeds current authority or needs clarification
@@ -35,6 +37,7 @@ skills/nelson/
       scuttle-and-reform.md   — Mission cannot succeed, abort and reform
       session-hygiene.md      — Clean start procedure for new sessions
       session-resumption.md   — Resuming an interrupted session
+      worktree-team-conflict.md — Recovery for #37549 worktree+team_name silent failure
     model-selection.md      — Cost-optimized model assignment for agents
     royal-marines.md        — Royal Marines deployment rules & specialisations
     squadron-composition.md — Mode selection & team sizing rules

--- a/hooks/nelson_hooks.py
+++ b/hooks/nelson_hooks.py
@@ -118,6 +118,38 @@ def _load_mission_context(
 
 
 # ---------------------------------------------------------------------------
+# Team config helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_team_config(teams_dir: Path, team_name: str) -> dict[str, Any]:
+    """Read a team's config.json. Returns empty dict on failure or invalid name."""
+    if not team_name or "/" in team_name or team_name.startswith("."):
+        return {}
+    return _read_json(teams_dir / team_name / "config.json")
+
+
+def _check_team_enrollment(
+    team_config: dict[str, Any], tool_input: dict[str, Any],
+) -> str | None:
+    """Return rejection message if the agent's name conflicts with an existing member."""
+    team_name = tool_input.get("team_name")
+    member_name = tool_input.get("name")
+    if not team_name or not member_name:
+        return None
+    members = team_config.get("members", [])
+    existing_names = {m.get("name") for m in members if isinstance(m, dict)}
+    if member_name in existing_names:
+        return (
+            f"Team enrollment violation: agent name '{member_name}' is "
+            f"already a member of team '{team_name}'. Spawning would "
+            f"create a duplicate. Choose a different ship name from "
+            f"references/crew-roles.md."
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Preflight helpers
 # ---------------------------------------------------------------------------
 
@@ -210,10 +242,15 @@ def cmd_preflight(args: argparse.Namespace) -> None:
     tasks = _get_tasks(battle_plan)
     tool_input = payload.get("tool_input", {})
 
+    teams_dir = Path.home() / ".claude" / "teams"
+    team_name = tool_input.get("team_name", "")
+    team_config = _read_team_config(teams_dir, team_name)
+
     for check in (
         lambda: _check_station_tiers(tasks),
         lambda: _check_file_ownership(tasks),
         lambda: _check_mode_tool_consistency(_get_mode(battle_plan), tool_input),
+        lambda: _check_team_enrollment(team_config, tool_input),
     ):
         msg = check()
         if msg:

--- a/hooks/test_nelson_hooks.py
+++ b/hooks/test_nelson_hooks.py
@@ -29,10 +29,12 @@ from nelson_hooks import (  # noqa: E402
     VALIDATION_EVIDENCE_PATTERNS,
     _check_running_plot_nonempty,
     _check_section_present,
+    _check_team_enrollment,
     _find_mission_dir,
     _get_mode,
     _get_tasks,
     _has_evidence,
+    _read_team_config,
     cmd_brief_validate,
     cmd_idle_ship,
     cmd_mode_check,
@@ -301,6 +303,39 @@ class TestPreflight:
         )
         assert code == 0
 
+    def test_preflight_rejects_duplicate_team_member(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _make_mission(
+            tmp_path,
+            mode="agent-team",
+            tasks=[{
+                "id": "task-1",
+                "name": "Refactor auth",
+                "owner": "HMS Argyll",
+                "station_tier": 1,
+                "file_ownership": ["src/auth.py"],
+            }],
+        )
+        # Build teams dir under tmp_path so Path.home() / ".claude" / "teams" resolves correctly
+        (tmp_path / ".claude").mkdir(exist_ok=True)
+        (tmp_path / ".claude" / "teams").mkdir(exist_ok=True)
+        (tmp_path / ".claude" / "teams" / "acme").mkdir(exist_ok=True)
+        (tmp_path / ".claude" / "teams" / "acme" / "config.json").write_text(
+            json.dumps({"members": [{"name": "HMS Argyll"}]}),
+        )
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        payload = {
+            "tool_input": {
+                "team_name": "acme",
+                "name": "HMS Argyll",
+                "prompt": "...",
+            },
+        }
+        code = _run(cmd_preflight, payload, cwd=str(tmp_path))
+        assert code == 2
+
 
 # ---------------------------------------------------------------------------
 # Mode-check
@@ -526,3 +561,55 @@ class TestIdleShip:
         _make_mission(tmp_path, fleet_status={"squadron": []})
         _run(cmd_idle_ship, {"teammate_name": "HMS Unknown"}, str(tmp_path))
         assert "not found" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Team config helpers
+# ---------------------------------------------------------------------------
+
+
+class TestReadTeamConfig:
+    def test_no_team_dir(self, tmp_path: Path) -> None:
+        assert _read_team_config(tmp_path / "missing", "acme") == {}
+
+    def test_team_dir_present_no_config(self, tmp_path: Path) -> None:
+        teams_dir = tmp_path / "teams"
+        (teams_dir / "acme").mkdir(parents=True)
+        assert _read_team_config(teams_dir, "acme") == {}
+
+    def test_team_config_loaded(self, tmp_path: Path) -> None:
+        teams_dir = tmp_path / "teams"
+        team_dir = teams_dir / "acme"
+        team_dir.mkdir(parents=True)
+        cfg = {"members": [{"name": "HMS Argyll"}, {"name": "HMS Kent"}]}
+        (team_dir / "config.json").write_text(json.dumps(cfg))
+        assert _read_team_config(teams_dir, "acme") == cfg
+
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        assert _read_team_config(tmp_path, "../../etc") == {}
+
+    def test_dotfile_rejected(self, tmp_path: Path) -> None:
+        assert _read_team_config(tmp_path, ".hidden") == {}
+
+
+class TestCheckTeamEnrollment:
+    def test_no_team_name_skips_check(self) -> None:
+        assert _check_team_enrollment({}, {"name": "HMS Argyll"}) is None
+
+    def test_no_name_provided(self) -> None:
+        cfg = {"members": [{"name": "HMS Argyll"}]}
+        assert _check_team_enrollment(cfg, {"team_name": "acme"}) is None
+
+    def test_duplicate_name_rejected(self) -> None:
+        cfg = {"members": [{"name": "HMS Argyll"}]}
+        msg = _check_team_enrollment(
+            cfg, {"team_name": "acme", "name": "HMS Argyll"},
+        )
+        assert msg is not None
+        assert "duplicate" in msg.lower()
+
+    def test_unique_name_allowed(self) -> None:
+        cfg = {"members": [{"name": "HMS Argyll"}]}
+        assert _check_team_enrollment(
+            cfg, {"team_name": "acme", "name": "HMS Kent"},
+        ) is None

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -119,6 +119,7 @@ Reference `references/admiralty-templates/battle-plan.md` for the battle plan te
 - `press-ganged-navigator.md`: Is the red-cell navigator being assigned implementation work?
 - `admiral-at-the-helm.md`: Does the battle plan assign any implementation work (excluding permitted read-only recombination) to the admiral?
 - `wrong-ensign.md`: Do the planned coordination tools match the selected execution mode?
+- `spawning-authority.md`: Does any task assign agent or marine spawning to a captain? Reassign to the admiral.
 
 If any answer triggers a standing order, you MUST apply the corrective action and re-answer the question before proceeding. For situations not covered by this gate, consult the Standing Orders table below.
 
@@ -130,6 +131,8 @@ If any answer triggers a standing order, you MUST apply the corrective action an
     - `single-session`: sequential tasks, low complexity, or heavy same-file editing.
     - `subagents`: parallel, fully independent tasks that report only to the admiral.
     - `agent-team`: captains benefit from a shared task list, peer messaging, or coordinated deliverables; or 4+ captains are needed.
+
+**Agent Teams Prerequisite:** Before committing to `agent-team` mode, confirm `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` was set at session launch — see `references/squadron-composition.md` for the quick check. If the env var is unset, `TeamCreate`/`SendMessage`/`team_name` are unavailable; fall back to `subagents` mode or have the admiral relaunch Claude Code with the env var set.
 
 **Mode-Tool Consistency Gate:** Before assigning ships, confirm your tool usage matches the selected mode by reviewing `references/tool-mapping.md`:
 - **`subagents` mode:** Captains do NOT use `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, or `SendMessage(type="message")`. Captains report via the `Agent` tool return value only. The admiral uses `TaskCreate`/`TaskUpdate`/`TaskList` to track progress in the session task list (visibility only — captains cannot see these tasks).
@@ -148,7 +151,7 @@ All tasks start as `pending`. They will be updated with owners and status as the
 - Assign each task a captain and a ship name from `references/crew-roles.md` matching task weight (frigate for general, destroyer for high-risk, patrol vessel for small, flagship for critical-path, submarine for research).
 - Finalize ship manifests: confirm crew roles per task, or note "Captain implements directly."
 - Add `1 red-cell navigator` for medium/high threat work. Do not exceed 10 squadron-level agents (admiral, captains, red-cell navigator). Crew are additional.
-- If the sailing orders express cost-savings priority, load `references/model-selection.md` before assigning models. Apply weight-based model selection to all `Agent` tool calls and include haiku briefing enhancements for agents assigned to haiku.
+- For each captain, record an explicit model in the formation summary using `references/model-selection.md`. In cost-savings missions, apply the weight-and-threshold rules to push appropriate roles to `haiku` and include haiku briefing enhancements. In standard missions, record `inherit` for ships that should use the admiral's model.
 
 ```
 SQUADRON FORMATION ORDERS
@@ -157,7 +160,7 @@ Mode: [single-session | subagents | agent-team]
 Captain count: [N]
 
 Ships:
-  [Ship name] — [vessel type] — [one-line task summary]
+  [Ship name] — [vessel type] — [station tier] — [mode] — [model] — [one-line task summary]
     Crew: [roles, or "Captain implements directly"]
   [repeat for each ship]
 
@@ -211,7 +214,7 @@ This registers all tasks, records the squadron, computes DAG metrics, and runs t
 - **`subagents` mode:** Use `TaskUpdate` to set `status` to `in_progress` as each captain is dispatched. The admiral tracks these directly.
 - **`single-session` mode:** Use `TaskUpdate` to set `status` to `in_progress` as the admiral begins each task.
 
-**Edit permissions:** When spawning any agent whose task involves editing files, set `mode: "acceptEdits"` on the `Agent` tool call. Omitting this can cause a permission race condition that silently stalls the agent at its first edit. When in doubt, include it.
+**Permission mode at spawn:** Set the `mode` parameter on every `Agent` tool call per the tier mapping in `references/action-stations.md` (Permission Mode by Station Tier). At minimum, captains whose task involves editing files MUST receive `mode: "acceptEdits"` to avoid silent permission stalls; Station 2 and Station 3 captains MUST receive `mode: "plan"` for the read-only review gate. The mapping is also recorded in the formation summary (Step 3 template).
 
 **Turnover Briefs:** When a ship is relieved due to context exhaustion, it writes a typed handoff packet using `python3 .claude/skills/nelson/scripts/nelson-data.py handoff ...` (see `references/structured-data.md`). An optional prose companion brief may also be written using `references/admiralty-templates/turnover-brief.md`. See `references/damage-control/relief-on-station.md` for the full procedure.
 
@@ -240,6 +243,8 @@ This transitions the mission from PERMISSION to UNDERWAY, unlocking agent spawni
 3. **Agent-team mode only:** Has the admiral received and processed this ship's results?
 
 If the task is complete and no pending task depends on it, proceed to shutdown per `references/standing-orders/paid-off.md`. In agent-team mode, the admiral must confirm receipt of the captain's results before sending `shutdown_request` — retrieve them via `SendMessage` or by reading output files if not already received. In subagents mode, results are returned synchronously by the `Agent` tool, so no additional confirmation is needed. Do not wait for the next checkpoint cadence. Check the current `TaskList` state at the moment the idle notification arrives; each notification is evaluated independently against current state. This applies even when other ships are still running.
+
+**Background-agent notifications:** Background captains (`Agent` with `run_in_background: true`) deliver completion notifications identical to foreground idle notifications — apply the same three questions above. Use `Monitor` to stream a background captain's output mid-task only when periodic visibility is needed; do not poll. See `references/background-patterns.md` for backgrounding criteria.
 
 **Shutdown attempt ceiling:** If a `shutdown_request` to a ship goes unacknowledged, do not loop indefinitely. After 3 failed attempts to the same agent, abandon the shutdown attempt, note the failure in the captain's log, and continue the mission. If `TeamDelete` is blocked by stuck agents, manual cleanup is available — see `references/damage-control/man-overboard.md` for the procedure.
 
@@ -343,6 +348,7 @@ Consult the specific standing order that matches the situation.
 | Captain completed autonomous work and needs human action to continue | `references/standing-orders/awaiting-admiralty.md` |
 | Agent completed task with no remaining work in the dependency graph | `references/standing-orders/paid-off.md` |
 | Using tools from the wrong execution mode | `references/standing-orders/wrong-ensign.md` |
+| Captain or crew attempting to spawn agents or marines | `references/standing-orders/spawning-authority.md` |
 
 ## Damage Control
 
@@ -361,6 +367,8 @@ Consult the specific procedure that matches the situation.
 | Automated budget, hull, and idle alarms crossing thresholds | `references/damage-control/circuit-breakers.md` |
 | Preparing the mission directory at session start | `references/damage-control/session-hygiene.md` |
 | Agent team communication failure (lost agent IDs, message bus down) | `references/damage-control/comms-failure.md` |
+| Agent spawn returns "Tool result missing due to internal error" with `team_name` | `references/damage-control/agent-team-spawn-broken.md` |
+| Captains share files despite `isolation: "worktree"` set | `references/damage-control/worktree-team-conflict.md` |
 
 ## Admiralty Doctrine
 

--- a/skills/nelson/references/action-stations.md
+++ b/skills/nelson/references/action-stations.md
@@ -112,13 +112,27 @@ Marine deployments inherit the parent ship's station tier:
 - **Station 2:** Captain must signal admiral and receive approval before deploying marines.
 - **Station 3:** Marine deployment is not permitted. All Trafalgar-tier work requires explicit Admiralty (human) confirmation.
 
-## Plan Mode for High-Risk Stations
+## Permission Mode by Station Tier
 
-When spawning captains for Station 2 or Station 3 tasks, use `mode: "plan"` on the `Agent` tool. This forces the captain into read-only plan mode — they can explore the codebase and design their approach, but cannot write files until the admiral approves their plan.
+When spawning captains, set `mode` on the `Agent` tool deliberately. The mapping below applies the minimum constraint required for each station tier — overriding only when the task itself demands it.
 
-- **Station 2 (Action):** Captain submits a plan via `ExitPlanMode`. Admiral reviews and approves via `SendMessage(type="plan_approval_response")`. This maps to the existing "admiral go/no-go" requirement.
-- **Station 3 (Trafalgar):** Same flow, but the admiral must also obtain explicit human confirmation before approving the plan. This maps to the existing "human confirmation required" requirement.
-- **Station 0-1:** Plan mode is not required. Captains execute directly.
+| Station tier | Default `mode` | Rationale |
+|---|---|---|
+| Station 0 (Patrol) | `acceptEdits` | Low blast radius; let the captain proceed without per-edit prompts. |
+| Station 1 (Caution) | `acceptEdits` | Moderate impact; rely on red-cell review and rollback notes for control. |
+| Station 2 (Action) | `plan` | Captain explores in read-only plan mode; admiral approves the plan via `SendMessage(type="plan_approval_response")` before execution. |
+| Station 3 (Trafalgar) | `plan` + human gate | Same as Station 2, plus the admiral must obtain explicit human confirmation before approving. |
+
+### Plan Mode Flow (Station 2 / 3)
+
+- The captain submits its plan via `ExitPlanMode`.
+- The admiral reviews and either approves via `SendMessage(type="plan_approval_response")` (agent-team mode) or by re-spawning the captain with `mode: "acceptEdits"` once the plan is approved (subagents mode).
+- Station 3 additionally requires explicit human confirmation before the admiral approves.
+
+### When to override the default
+
+- Use `mode: "plan"` for any captain whose task involves exploration before changes, regardless of tier.
+- Use `mode: "default"` (the unset value) only when the captain is a pure-read operation (Explore subagents, Coxswain, Recce Marines).
 
 See `references/tool-mapping.md` for the full set of coordination tools.
 

--- a/skills/nelson/references/background-patterns.md
+++ b/skills/nelson/references/background-patterns.md
@@ -1,0 +1,60 @@
+# Background Agent Patterns
+
+Use this reference when a captain's task is long-running and would otherwise block the admiral's quarterdeck rhythm. Background agents free the admiral to process other captains' completions while a long-running task continues.
+
+## When to background a captain
+
+- The task duration exceeds two quarterdeck checkpoint intervals.
+- The captain is producing intermediate output that the admiral does not need to review until completion (long builds, large refactors, exhaustive test runs).
+- The captain has no upstream dependencies on other captains' output.
+
+Do NOT background:
+- Station 2 or Station 3 captains — admiral oversight is required.
+- Captains whose output unblocks others (the admiral must be present to relay).
+- Captains in `agent-team` mode where peer-messaging from other captains may require routing.
+
+## Spawning a background captain
+
+Use `run_in_background: true` on the `Agent` tool:
+
+```
+Agent(
+  name="HMS Argyll",
+  subagent_type="general-purpose",
+  prompt="<captain brief>",
+  mode="acceptEdits",
+  model="sonnet",
+  run_in_background=true,
+)
+```
+
+The admiral receives a notification when the background agent completes; do not poll, do not insert sleep loops. Continue the quarterdeck rhythm with foreground captains while the background agent runs.
+
+## Monitoring a background captain mid-task
+
+Use the `Monitor` tool to stream events from a background agent's stdout. Each output line arrives as a notification:
+
+```
+Monitor(target="HMS Argyll")
+```
+
+Monitor is appropriate when:
+- The captain's progress is visible in stdout and the admiral wants periodic visibility without spawning a quarterdeck checkpoint specifically for this ship.
+- A circuit-breaker condition (token budget overrun, hull-integrity threshold) needs to be detected from output rather than a checkpoint.
+
+If you only need to know when the background agent is done, do not start a Monitor — the completion notification is sufficient.
+
+## Quarterdeck integration
+
+When a background agent's completion notification arrives:
+1. Treat it identically to a foreground idle notification — apply the three questions in `SKILL.md` Step 5.
+2. Mark the captain's task `completed` in the shared task list (or session task list in `subagents` mode).
+3. Continue the rhythm; do not write a checkpoint specifically for the background agent unless the cadence rule requires it.
+
+If a background agent's circuit-breaker trips (hull integrity Red, idle timeout), invoke the corresponding damage-control procedure exactly as for a foreground captain.
+
+## Related
+
+- `references/damage-control/circuit-breakers.md` — automated breaker rules.
+- `references/damage-control/hull-integrity.md` — threshold response.
+- `references/tool-mapping.md` — Long-Running Tools section.

--- a/skills/nelson/references/damage-control/agent-team-spawn-broken.md
+++ b/skills/nelson/references/damage-control/agent-team-spawn-broken.md
@@ -1,0 +1,59 @@
+# Agent Team Spawn Broken
+
+Use when spawning a captain via `Agent(team_name=..., name=...)` returns
+`[Tool result missing due to internal error]` or otherwise silently fails to
+produce a teammate.
+
+This is a known upstream regression — see
+[claude-code#40270](https://github.com/anthropics/claude-code/issues/40270).
+The `team_name` parameter on the `Agent` tool currently triggers an internal
+error in the teammate spawn path even when `TeamCreate` and `TaskCreate`
+succeed first. The issue is open as of April 2026.
+
+## Symptoms
+
+- `Agent(team_name="...", name="...")` returns `[Tool result missing due to
+  internal error]` or empty content with no captain spawned.
+- `TeamCreate` succeeded but the team has no enrolled members afterwards.
+- The admiral cannot reach any captain via `SendMessage` because no captains
+  exist.
+
+## Procedure
+
+1. Confirm the failure is the `#40270` regression by retrying once. If the
+   second `Agent(team_name=...)` call returns the same error, treat the
+   experimental Agent Teams spawn path as unavailable for this session.
+2. Stand down the empty team if `TeamCreate` succeeded but no members
+   enrolled:
+
+   ```
+   TeamDelete(team_name="<name>")
+   ```
+
+3. Fall back to `subagents` mode for the rest of the mission:
+   - Update `battle-plan.json` `squadron.mode` to `subagents`.
+   - Re-run the conflict scan: `python3 .claude/skills/nelson/scripts/nelson_conflict_scan.py --plan {mission-dir}/battle-plan.json`.
+   - Re-spawn captains with `Agent(subagent_type="general-purpose", ...)`
+     instead of `Agent(team_name=..., name=...)`.
+   - Reassign captain visibility tracking via the admiral's
+     `TaskCreate`/`TaskUpdate` calls (admiral exception, not captain
+     coordination).
+4. Log the regression and mode change in the captain's log so future
+   missions know to check #40270 status before selecting `agent-team`.
+
+## Prevention
+
+- At the start of every `agent-team` mission, the admiral should make ONE
+  test spawn before assigning the full squadron. If that spawn fails with
+  the #40270 symptom, abort `agent-team` mode and select `subagents`
+  instead before any tasks are committed.
+- When upstream confirms a fix, remove this damage-control entry and the
+  preflight check. Track the issue's status when planning new missions.
+
+## Related
+
+- `references/standing-orders/wrong-ensign.md` — mode/tool consistency.
+- `references/damage-control/comms-failure.md` — broader infrastructure
+  failure recovery.
+- `references/squadron-composition.md` — mode selection (which now warns
+  about #40270).

--- a/skills/nelson/references/damage-control/worktree-team-conflict.md
+++ b/skills/nelson/references/damage-control/worktree-team-conflict.md
@@ -1,0 +1,52 @@
+# Worktree + Team Name Conflict
+
+Use when a captain spawned with both `team_name` and `isolation: "worktree"`
+appears to be running in the main repository instead of an isolated worktree.
+
+This is a known upstream bug — see
+[claude-code#37549](https://github.com/anthropics/claude-code/issues/37549).
+The combination silently lands the captain in the main repo with no error
+raised, defeating the isolation guarantee. The bug is open as of April
+2026.
+
+## Symptoms
+
+- Multiple captains spawned with `isolation: "worktree"` write to the same
+  files and produce merge-style conflicts where none should be possible.
+- `git worktree list` shows fewer worktrees than captains spawned.
+- Captain logs reference paths in the main repo rather than under
+  `.claude/worktrees/`.
+
+## Procedure
+
+1. Detect: after spawning the squadron, run
+   `git worktree list` and compare the count to the number of captains
+   intended to be isolated. Mismatch confirms the bug.
+2. If captains have already started writing, pause them via
+   `SendMessage(type="message")` instructing them to stop and report
+   current state.
+3. Choose one of two recovery paths:
+   - **Path A (preferred): drop worktree isolation, enforce file ownership.**
+     Update the battle plan so each captain owns disjoint files
+     (`split-keel.md`). Re-run `nelson_conflict_scan.py` to confirm no
+     overlap. Continue in `agent-team` mode without isolation.
+   - **Path B: drop `agent-team` mode, keep worktrees.** Stand down the
+     team via `TeamDelete`. Switch `squadron.mode` to `subagents` (which
+     spawns via `subagent_type` and supports worktree isolation correctly).
+     Re-spawn each captain with `isolation: "worktree"` only.
+4. Log the bug and chosen recovery path in the captain's log.
+
+## Prevention
+
+- Until #37549 is fixed, do not combine `team_name` with `isolation:
+  "worktree"` in the same `Agent` call. Choose one or the other:
+  `agent-team` mode without worktrees, or `subagents` mode with worktrees.
+- The squadron-composition reference now reflects this constraint.
+
+## Related
+
+- `references/squadron-composition.md` — Worktree Isolation guidance.
+- `references/standing-orders/split-keel.md` — file ownership as the
+  primary conflict-prevention mechanism.
+- `references/damage-control/agent-team-spawn-broken.md` — companion bug
+  in the same surface area (#40270).

--- a/skills/nelson/references/model-selection.md
+++ b/skills/nelson/references/model-selection.md
@@ -1,6 +1,12 @@
 # Model Selection
 
-Use this reference when the sailing orders express cost-savings priority. It governs model assignment for all squadron agents.
+This reference governs `model` parameter assignment for all squadron agents. **All missions** must record an explicit model per ship in the formation summary (visibility); cost-savings missions additionally apply the weight-and-threshold rules below to override defaults toward `haiku`.
+
+## Default behaviour (no cost-savings priority)
+
+- The admiral records each ship's model in the formation summary as `inherit` (i.e. the admiral's model) unless a ship's role definition recommends otherwise.
+- The `model` parameter is **omitted** from the `Agent` tool call when the ship inherits — explicit `"sonnet"` resolves to an older alias and does not match the admiral's model.
+- This makes model assignment auditable in the squadron summary even when no parameter is passed at spawn.
 
 ## Detecting Cost-Savings Intent
 

--- a/skills/nelson/references/squadron-composition.md
+++ b/skills/nelson/references/squadron-composition.md
@@ -6,6 +6,18 @@ Use this file to choose execution mode and team size.
 
 **User preference override:** If the user explicitly requests a specific execution mode (e.g., "use agent teams"), that request MUST be honoured. User preference takes priority over the decision matrix below. Do not second-guess or override the user's choice.
 
+## Prerequisite for `agent-team` Mode
+
+`agent-team` mode requires the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` environment variable to be set when Claude Code launched. Without it, `TeamCreate`, `SendMessage` between captains, and the `team_name` parameter on `Agent` are unavailable or silently degrade.
+
+**Quick check before selecting `agent-team`:**
+
+1. Inspect the tool surface available in this session — if `TeamCreate` is not listed in the available tools, the env var is unset.
+2. If unset, fall back to `subagents` mode, or ask the admiral to relaunch Claude Code with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude ...`.
+3. Do not proceed past mode selection assuming agent-team capabilities will appear later — the env var is read at session start only.
+
+> **Bug status:** Even when the env var is set, `Agent(team_name=...)` may fail with an internal error per [claude-code#40270](https://github.com/anthropics/claude-code/issues/40270). See `references/damage-control/agent-team-spawn-broken.md` for the workaround.
+
 Evaluate all three conditions and select the best fit. When two modes could apply, prefer the one that gives captains more autonomy.
 
 - `single-session`: Work is sequential, tightly coupled, or mostly in the same files.
@@ -59,3 +71,9 @@ Worktree isolation is a stronger alternative to the file-ownership approach in `
 - Tasks are large enough that the merge cost is justified.
 
 **Trade-off:** Worktree isolation prevents conflicts during execution but requires merging changes afterward. The admiral is responsible for coordinating the merge.
+
+> **⚠ Known bug — do not combine `team_name` with `isolation: "worktree"`.** Per [claude-code#37549](https://github.com/anthropics/claude-code/issues/37549), the combination silently lands the captain in the main repo, defeating isolation. Choose one:
+> - `agent-team` mode → enforce file ownership via `standing-orders/split-keel.md`, no worktrees.
+> - `subagents` mode → use `isolation: "worktree"` freely (subagent spawning is unaffected).
+>
+> See `references/damage-control/worktree-team-conflict.md` for the recovery procedure.

--- a/skills/nelson/references/standing-orders/spawning-authority.md
+++ b/skills/nelson/references/standing-orders/spawning-authority.md
@@ -1,0 +1,37 @@
+# Standing Order: Spawning Authority
+
+Only the admiral spawns agents and Royal Marines.
+
+Captains and crew operate inside an isolated teammate context that does NOT include the `Agent` or `TeamCreate` tools. A captain that "deploys" a marine or "spawns" a sub-agent without admiral involvement cannot succeed — those tool calls are not present in the captain's tool surface.
+
+This is not a stylistic rule; it is a structural constraint of Claude Code's teammate spawning model. The instruction set in `references/royal-marines.md` and `references/crew-roles.md` may read as if captains deploy crew or marines directly. They do not. The admiral spawns on a captain's behalf when the captain requests support.
+
+**Symptoms:**
+
+- A captain attempts an `Agent` call and receives "tool not available" or no result.
+- A captain's brief instructs them to "spawn a marine" or "deploy a Recce" without specifying how to request the deployment.
+- Marine deployments appear in the battle plan with a captain as the spawner rather than the admiral.
+
+**Correct flow:**
+
+1. Captain identifies need for marine support (per `references/royal-marines.md` deployment rules).
+2. Captain sends `SendMessage(type="message")` to the admiral with a marine deployment brief (using `references/admiralty-templates/marine-deployment-brief.md`).
+3. Admiral evaluates the request against station-tier rules (Station 2 requires admiral approval before deployment per `references/action-stations.md`).
+4. Admiral spawns the marine via `Agent(subagent_type="general-purpose", ...)` (or other suitable subagent type), passing the captain's brief as the marine's prompt.
+5. Marine reports back to the admiral. The admiral relays results to the captain via `SendMessage`.
+
+**When the captain is in subagents mode:**
+
+- There is no `SendMessage` channel back to the admiral. The captain instead returns control via the `Agent` return value with a "marine support requested" note. The admiral inspects the return value, decides, and spawns a follow-up subagent for the marine work.
+
+**Remedy when violated:**
+
+- If a captain's brief implies they will spawn a marine, rewrite the brief to instruct them to **request** the deployment via `SendMessage` (or via the Agent return value in subagents mode).
+- If marine deployments appear in the battle plan with a captain as spawner, reassign the spawner to "Admiral" before formation closes.
+
+**Related:**
+
+- `references/royal-marines.md` — marine deployment rules.
+- `references/admiralty-templates/marine-deployment-brief.md` — request format.
+- `references/action-stations.md` — Marine Deployments section, station-tier gates.
+- `references/crew-roles.md` — crew composition (also admiral-spawned).

--- a/skills/nelson/references/standing-orders/wrong-ensign.md
+++ b/skills/nelson/references/standing-orders/wrong-ensign.md
@@ -17,6 +17,10 @@ spawned with mismatched parameters cannot communicate with the squadron.
 - Admiral attempting to retrieve results via `TaskGet` when captains were
   dispatched as teammates (agent-team mode).
 - Captains unable to update shared task state because no task list exists.
+- `TeamCreate` not listed in the available tools, indicating
+  `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` was not set at session launch
+  (agent-team mode requires this prerequisite — see
+  `references/squadron-composition.md`).
 
 **Remedy:** Before spawning any agents, review `references/tool-mapping.md` and
 confirm every planned tool call is valid for the selected execution mode:

--- a/skills/nelson/references/tool-mapping.md
+++ b/skills/nelson/references/tool-mapping.md
@@ -63,3 +63,13 @@ Common mode-tool mismatches and their correct alternatives. See
 | `Agent` with `subagent_type` to spawn a captain in agent-team mode | Agent is not registered as a teammate | Use `Agent` with `team_name` + `name` |
 | `TeamCreate` in subagents mode | Creates an unnecessary team structure | Omit — spawn captains directly with `Agent` |
 | `TaskCreate` by captains in subagents mode | No shared task list exists for captains | Admiral tracks visibility via `TaskCreate`/`TaskUpdate` in its own session; captains report via `Agent` return value |
+
+## Long-Running Tools
+
+| Nelson Operation | Claude Code Tool | Mode |
+|---|---|---|
+| Spawn captain in background | `Agent` with `run_in_background: true` | subagents / agent-team (Station 0-1 only) |
+| Stream a background captain's output | `Monitor` with target=ship name | all modes |
+| Wait for any pending notification | (no explicit call) | all modes |
+
+See `references/background-patterns.md` for when to background a captain and how to integrate completion notifications into the quarterdeck rhythm.


### PR DESCRIPTION
## Summary

Re-introduces the Agent Teams capabilities from the original #106, which was reverted from main to decouple it from the v2.2.0 release.

- Background-agent and Monitor coordination patterns
- Team-aware enrollment validation in preflight hook
- Explicit model-per-captain recording in all missions
- Action Stations tier → `Agent.mode` mapping in spawn templates
- Standing order: only the admiral spawns agents/marines
- Damage control procedures for `Agent(team_name=...)` breakage (#40270) and worktree+team silent failure (#37549)

## Original PR
Closes the work originally merged in #106.

## Test plan
- [ ] Verify preflight hook validates team enrollment
- [ ] Verify background-patterns reference loads correctly
- [ ] Verify damage-control procedures are accessible
- [ ] Verify standing-orders/spawning-authority renders
- [ ] Run existing hook tests