### PR TITLE
fix: prevent captains from creating parallel implementations when extending existing code

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -96,7 +96,9 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py advance --mission-dir {mis
 
 When The Estimate has been conducted, the Battle Plan inherits the analytical work: terrain, forces, coordination, and control are already decided. The Battle Plan step is operational — it turns approved effects into task assignments. When the Estimate was skipped, the admiral performs the analysis inline at this step.
 
-- Translate each effect from the Estimate (§3) into one or more tasks. When the Estimate was skipped, derive tasks directly from the Sailing Orders.
+**Scope preservation:** When the Sailing Orders describe extending, expanding, or modifying an existing feature, every task must modify the existing implementation — not create a parallel or replacement implementation. Each task's deliverable and file ownership must reference the existing code it extends. If the Estimate's effects already identify the existing code (and they should — that is what Reconnaissance is for), the Battle Plan must not lose that anchor. A task that creates new files where an extension of existing files would satisfy the effect is a planning error.
+
+- Translate each effect from the Estimate (§3) into one or more tasks. Each task must stay within the scope of its parent effect — do not introduce work that the effect does not call for. When the Estimate was skipped, derive tasks directly from the Sailing Orders.
 - Prepend the commander's intent paragraph (Estimate §2) to every captain's brief so each ship sails under a shared understanding of purpose.
 - Inherit acceptance criteria from the parent effect onto each task. Captains own the choice of verification method per criterion.
 - Inherit terrain (file ownership), coordination (dependencies), forces (captain sizing, model class), and control (action-station tier) from the Estimate. When the Estimate was skipped, supply these at this step.

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -96,7 +96,7 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py advance --mission-dir {mis
 
 When The Estimate has been conducted, the Battle Plan inherits the analytical work: terrain, forces, coordination, and control are already decided. The Battle Plan step is operational — it turns approved effects into task assignments. When the Estimate was skipped, the admiral performs the analysis inline at this step.
 
-**Scope preservation:** When the Sailing Orders describe extending, expanding, or modifying an existing feature, every task must modify the existing implementation — not create a parallel or replacement implementation. Each task's deliverable and file ownership must reference the existing code it extends. If the Estimate's effects already identify the existing code (and they should — that is what Reconnaissance is for), the Battle Plan must not lose that anchor. A task that creates new files where an extension of existing files would satisfy the effect is a planning error.
+**Scope preservation:** When the Sailing Orders describe extending, expanding, or modifying an existing feature, every task must modify the existing implementation — not create a parallel or replacement implementation. Populate the `Modification targets` field in each task's brief with the specific functions, env vars, and config identified during Reconnaissance. A task that creates new files, functions, or environment variables where modification of existing ones would satisfy the effect is a planning error.
 
 - Translate each effect from the Estimate (§3) into one or more tasks. Each task must stay within the scope of its parent effect — do not introduce work that the effect does not call for. When the Estimate was skipped, derive tasks directly from the Sailing Orders.
 - Prepend the commander's intent paragraph (Estimate §2) to every captain's brief so each ship sails under a shared understanding of purpose.
@@ -260,7 +260,7 @@ If the task is complete and no pending task depends on it, proceed to shutdown p
     - Check hull integrity: collect damage reports from all ships, update the squadron readiness board, and take action per `references/damage-control/hull-integrity.md`. The admiral must also check its own hull integrity at each checkpoint. **Every ship must file a damage report at every checkpoint** to `{mission-dir}/damage-reports/{ship-name}.json` using the schema in `references/admiralty-templates/damage-report.md` — do not skip this when hull is Green.
     - Standing order scan: For each order below, ask "Has this situation arisen since the last checkpoint?" If yes, apply the corrective action now — do not defer.
         - `admiral-at-the-helm.md`: Has the admiral drifted into implementation work (excluding permitted read-only recombination)?
-        - `drifting-anchorage.md`: Has any task scope crept beyond the sailing orders?
+        - `drifting-anchorage.md`: Has any task scope crept beyond the sailing orders? Has any captain created a parallel implementation, duplicate function, or new environment variable instead of extending existing code?
         - `captain-at-the-capstan.md`: Has any captain started implementing instead of coordinating crew?
         - `pressed-crew.md`: Has any crew member been assigned work outside their role?
         - `press-ganged-navigator.md`: Has the red-cell navigator been assigned implementation work?

--- a/skills/nelson/references/admiralty-templates/battle-plan.md
+++ b/skills/nelson/references/admiralty-templates/battle-plan.md
@@ -31,7 +31,7 @@ Task ID:
 
 **Acceptance criteria inheritance.** Each task inherits the acceptance criteria of its parent effect from the Estimate (§3). Captains own the choice of verification method per criterion (test, type-check, lint, review, or visual). The quarterdeck records each outcome (`pass` / `fail` / `not-verified`) via `nelson-data.py estimate-outcome`.
 
-JSON schema note: the battle-plan `task` object accepts an optional `acceptance_criteria: list[str]` field carrying the inherited criteria. This enables programmatic aggregation of verification outcomes.
+JSON schema note: the battle-plan `task` object accepts an optional `acceptance_criteria: list[str]` field carrying the inherited criteria. This enables programmatic aggregation of verification outcomes. The `task` object also accepts an optional `modification_targets: list[str]` field for tracking the functions, environment variables, or configuration that must be modified in place.
 
 **`admiralty-action-required`:** Mark `yes` for any task where a step cannot be completed by an agent — requires the human to interact with an external system, provide credentials or URLs, or take an action only the human can perform. Fill this field consciously for every task; leaving it blank is a claim that the task requires no human action. When marked `yes`, the admiral will surface this in the Admiralty Action List before agents launch, and the captain will invoke the `awaiting-admiralty` standing order when the step is reached.
 

--- a/skills/nelson/references/admiralty-templates/battle-plan.md
+++ b/skills/nelson/references/admiralty-templates/battle-plan.md
@@ -15,6 +15,7 @@ Task ID:
 - Dependencies:
 - Station tier (0-3):
 - File ownership (if code):
+- Modification targets (if extending): [specific functions, env vars, config to modify — not replace. Omit for greenfield tasks.]
 - Acceptance criteria (inherited from effect):
   - [Criterion 1 — captain chooses verification method: test | type-check | lint | review | visual]
   - [Criterion 2 — ...]
@@ -25,6 +26,8 @@ Task ID:
   - timing: before this task starts | after this task completes
   - blocks: [task name or "stand-down"]
 ```
+
+**Modification targets.** When a task extends existing code, the `Modification targets` field anchors the captain to specific functions, variables, and configuration that must be modified in place. This field flows from the Estimate's Reconnaissance (Q1) and Terrain (Q4) — if those questions identified the existing code, the Battle Plan must preserve that specificity. Omit the field for greenfield tasks where no existing code is being extended.
 
 **Acceptance criteria inheritance.** Each task inherits the acceptance criteria of its parent effect from the Estimate (§3). Captains own the choice of verification method per criterion (test, type-check, lint, review, or visual). The quarterdeck records each outcome (`pass` / `fail` / `not-verified`) via `nelson-data.py estimate-outcome`.
 

--- a/skills/nelson/references/admiralty-templates/crew-briefing.md
+++ b/skills/nelson/references/admiralty-templates/crew-briefing.md
@@ -24,6 +24,10 @@ Standing Orders:
 - Do NOT implement work outside your assigned task scope
 - Do NOT edit files not assigned to you
 - If any part of your task is ambiguous, signal the admiral before implementing
+- When your task extends existing code, modify the existing implementation in place.
+  Do NOT create replacement functions, parallel implementations, or new environment
+  variables that duplicate existing ones. If you believe a rewrite is necessary,
+  signal the admiral with your rationale before proceeding.
 - Report blockers to admiral immediately with options and one recommendation
 - Execution mode: [subagents | agent-team] — your available coordination tools are listed in references/tool-mapping.md
 - When done, report: deliverable, validation evidence, failure modes, rollback note

--- a/skills/nelson/references/standing-orders/drifting-anchorage.md
+++ b/skills/nelson/references/standing-orders/drifting-anchorage.md
@@ -6,5 +6,9 @@ Do not allow tasks to expand scope beyond the original sailing orders without re
 - Captains add features or refactors not in the battle plan.
 - Mission metric is no longer connected to active work.
 - Token and time budgets overrun without corresponding mission progress.
+- Captain creates new functions, files, or environment variables that duplicate existing ones instead of extending them.
+- Existing implementation is deprecated, bypassed, or shadowed rather than modified.
 
 **Remedy:** When scope drift is detected during a quarterdeck checkpoint, re-scope the task or split it. Work that falls outside the sailing orders must be deferred or explicitly added with admiral approval.
+
+When a captain creates a parallel implementation instead of extending existing code, direct the captain to remove the duplicate and modify the existing implementation. If the task is already completed, apply partial rollback per `references/damage-control/partial-rollback.md` and re-task with explicit modification targets.

--- a/skills/nelson/references/structured-data.md
+++ b/skills/nelson/references/structured-data.md
@@ -52,7 +52,8 @@ python3 .claude/skills/nelson/scripts/nelson-data.py task \
   --id 1 --name "Auth module refactor" --owner "HMS Argyll" \
   --deliverable "Refactored auth module with JWT support" \
   --deps "" --station-tier 1 \
-  --files "src/auth/**"
+  --files "src/auth/**" \
+  --modification-targets "auth_handler, JWT_SECRET"
 ```
 
 ### `plan-approved` — Finalize battle plan
@@ -182,7 +183,8 @@ The plan JSON file must contain `squadron` and `tasks` keys:
       "deliverable": "Refactored auth module with JWT support",
       "dependencies": [],
       "station_tier": 1,
-      "file_ownership": ["src/auth/**"]
+      "file_ownership": ["src/auth/**"],
+      "modification_targets": ["auth_handler", "JWT_SECRET"]
     }
   ]
 }
@@ -461,6 +463,7 @@ All artifacts are stored in `{mission-dir}/`.
       "dependents": [4],
       "station_tier": 1,
       "file_ownership": ["src/auth/**"],
+      "modification_targets": ["auth_handler", "JWT_SECRET"],
       "validation_required": "Unit tests pass, no API surface change",
       "rollback_note_required": true,
       "admiralty_action_required": false

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -135,6 +135,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_task.add_argument(
         "--files", default="", help="Comma-separated file glob patterns"
     )
+    p_task.add_argument(
+        "--modification-targets",
+        default="",
+        help="Comma-separated functions, env vars, or config being extended",
+    )
     p_task.add_argument("--validation", default=None, help="Validation criteria")
     p_task.add_argument(
         "--rollback-note", action="store_true", help="Rollback note required"

--- a/skills/nelson/scripts/nelson_data_lifecycle.py
+++ b/skills/nelson/scripts/nelson_data_lifecycle.py
@@ -347,6 +347,10 @@ def cmd_task(args: argparse.Namespace) -> None:
     if args.files:
         files = [f.strip() for f in args.files.split(",") if f.strip()]
 
+    mod_targets: list[str] = []
+    if getattr(args, "modification_targets", None):
+        mod_targets = [m.strip() for m in args.modification_targets.split(",") if m.strip()]
+
     task: dict[str, Any] = {
         "id": args.id,
         "name": args.name,
@@ -356,6 +360,7 @@ def cmd_task(args: argparse.Namespace) -> None:
         "dependents": [],
         "station_tier": args.station_tier,
         "file_ownership": files,
+        "modification_targets": mod_targets,
         "validation_required": args.validation or None,
         "rollback_note_required": bool(args.rollback_note),
         "admiralty_action_required": bool(args.admiralty_action),
@@ -1225,6 +1230,7 @@ def _build_task_record(
     deps: list[int],
     station_tier: int,
     files: list[str],
+    modification_targets: list[str] | None = None,
     validation: str | None = None,
     rollback_note: bool = False,
     admiralty_action: bool = False,
@@ -1239,6 +1245,7 @@ def _build_task_record(
         "dependents": [],
         "station_tier": station_tier,
         "file_ownership": list(files),
+        "modification_targets": list(modification_targets or []),
         "validation_required": validation or None,
         "rollback_note_required": rollback_note,
         "admiralty_action_required": admiralty_action,
@@ -1521,6 +1528,7 @@ def _do_form(
             deps=list(t.get("dependencies", [])),
             station_tier=t["station_tier"],
             files=list(t.get("file_ownership", [])),
+            modification_targets=list(t.get("modification_targets", [])),
             validation=t.get("validation_required"),
             rollback_note=bool(t.get("rollback_note_required", False)),
             admiralty_action=bool(t.get("admiralty_action_required", False)),


### PR DESCRIPTION
## Summary

Fixes a reported failure mode where Nelson creates a parallel implementation instead of extending an existing one, even when the Estimate and Battle Plan correctly identify the existing code.

### User feedback

> "Seems good, tho I tried using this to expand on one feature but it instead create a new feature even though the estimate already correct."

Follow-up clarification:

> "I have a feature that kinda doing a 'sync' from google sheets. Save the spreadsheet ID and tab name in environment var. Then I tried to expand this feature by the way of adding more columns to sync. I ran Nelson, the estimate and battle plan already noticed I already have such feature and it will add to it. Implementation done, push, CI/deployment failed. I checked, I found that there are new env for spreadsheet ID and tab name which are blank. Asked Nelson again (in new session), and it says there are two function and one deprecate the other."

### Root cause

The Estimate and Battle Plan correctly identified the existing feature, but the implementing captain created a new function with new (blank) env vars instead of modifying the existing one. The information was lost between the Battle Plan and captain execution — not during planning.

### Changes

- **Crew briefing template** (`crew-briefing.md`): Add standing order telling captains to modify existing implementations in place, not create parallel replacements
- **Battle plan template** (`battle-plan.md`): Add "Modification targets" field so the plan specifies exact functions/env vars to modify, not just file ownership
- **Drifting anchorage standing order** (`drifting-anchorage.md`): Expand symptoms and remedy to catch parallel-implementation drift
- **SKILL.md Step 3**: Add scope-preservation paragraph as belt-and-suspenders insurance at the planning layer

## Test plan

- [ ] Run a mission with Sailing Orders that say "expand feature X" and verify the Battle Plan produces tasks with explicit modification targets
- [ ] Verify the crew briefing includes the "do not create parallel implementations" standing order
- [ ] Confirm captains receive modification targets in their brief and modify existing code rather than creating replacements
- [ ] Verify no regression on missions that genuinely require new files/functions
- [ ] Check that the quarterdeck checkpoint catches parallel-implementation drift via expanded drifting-anchorage symptoms