### PR TITLE
fix: remove TaskCreate mode-check hook that contradicts admiral exception (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ Nelson is not purely advisory. A set of Claude Code hooks (`hooks/nelson_hooks.p
 | Event | Hook | What it enforces |
 |---|---|---|
 | `PreToolUse` on `Agent` | `preflight` | Station tier gate, file ownership conflicts, mode-tool consistency |
-| `PreToolUse` on `TaskCreate` | `mode-check` | Rejects task creation in non-agent-team modes |
 | `PostToolUse` on `Write`/`Edit` | `brief-validate` | Turnover brief quality gate |
 | `TaskCompleted` | `task-complete` | Validation evidence and station controls |
 | `TeammateIdle` | `idle-ship` | Paid-off standing order advisory |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -9,15 +9,6 @@
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/nelson_hooks.py\" preflight"
           }
         ]
-      },
-      {
-        "matcher": "TaskCreate",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/nelson_hooks.py\" mode-check"
-          }
-        ]
       }
     ],
     "PostToolUse": [

--- a/hooks/nelson_hooks.py
+++ b/hooks/nelson_hooks.py
@@ -7,7 +7,6 @@ hooks. Each subcommand maps to a hook event type:
 
   preflight      — PreToolUse on Agent: station tier gate, file ownership
                    conflicts, mode-tool consistency
-  mode-check     — PreToolUse on TaskCreate: reject in non-agent-team modes
   brief-validate — PostToolUse on Write/Edit: turnover brief quality gate
   task-complete  — TaskCompleted: validation evidence and station controls
   idle-ship      — TeammateIdle: paid-off standing order advisory
@@ -218,31 +217,6 @@ def cmd_preflight(args: argparse.Namespace) -> None:
         msg = check()
         if msg:
             _reject(msg)
-
-    _allow()
-
-
-# ---------------------------------------------------------------------------
-# Subcommand: mode-check (PreToolUse on TaskCreate)
-# ---------------------------------------------------------------------------
-
-
-def cmd_mode_check(args: argparse.Namespace) -> None:
-    """Reject TaskCreate in non-agent-team execution modes."""
-    payload = _read_stdin()
-    ctx = _load_mission_context(payload)
-    if ctx is None:
-        _allow()
-
-    _, battle_plan = ctx
-    mode = _get_mode(battle_plan)
-    if mode in ("subagents", "single-session"):
-        _reject(
-            f"Standing order violation (wrong-ensign): "
-            f"TaskCreate is not available in {mode} mode. "
-            f"Track work in the admiral's conversation context. "
-            f"See references/tool-mapping.md."
-        )
 
     _allow()
 
@@ -670,10 +644,6 @@ def main() -> None:
         help="Pre-flight standing order gate (PreToolUse on Agent)",
     )
     subparsers.add_parser(
-        "mode-check",
-        help="Mode-tool consistency check (PreToolUse on TaskCreate)",
-    )
-    subparsers.add_parser(
         "brief-validate",
         help="Turnover brief quality gate (PostToolUse on Write/Edit)",
     )
@@ -690,7 +660,6 @@ def main() -> None:
 
     dispatch = {
         "preflight": cmd_preflight,
-        "mode-check": cmd_mode_check,
         "brief-validate": cmd_brief_validate,
         "task-complete": cmd_task_complete,
         "idle-ship": cmd_idle_ship,

--- a/hooks/test_nelson_hooks.py
+++ b/hooks/test_nelson_hooks.py
@@ -1,8 +1,7 @@
 """Tests for nelson_hooks.py — hook enforcement script.
 
-Tests the preflight, mode-check, brief-validate, task-complete,
-and idle-ship subcommands using temporary mission directories and
-monkeypatched stdin.
+Tests the preflight, brief-validate, task-complete, and idle-ship
+subcommands using temporary mission directories and monkeypatched stdin.
 """
 
 from __future__ import annotations
@@ -35,7 +34,6 @@ from nelson_hooks import (  # noqa: E402
     _has_evidence,
     cmd_brief_validate,
     cmd_idle_ship,
-    cmd_mode_check,
     cmd_preflight,
     cmd_task_complete,
 )
@@ -300,28 +298,6 @@ class TestPreflight:
             cwd=str(tmp_path),
         )
         assert code == 0
-
-
-# ---------------------------------------------------------------------------
-# Mode-check
-# ---------------------------------------------------------------------------
-
-
-class TestModeCheck:
-    def test_no_mission_allows(self, tmp_path: Path) -> None:
-        assert _run(cmd_mode_check, {"tool_name": "TaskCreate", "tool_input": {}}, str(tmp_path)) == 0
-
-    def test_subagents_mode_rejects(self, tmp_path: Path) -> None:
-        _make_mission(tmp_path, mode="subagents")
-        assert _run(cmd_mode_check, {"tool_name": "TaskCreate", "tool_input": {}}, str(tmp_path)) == 2
-
-    def test_single_session_rejects(self, tmp_path: Path) -> None:
-        _make_mission(tmp_path, mode="single-session")
-        assert _run(cmd_mode_check, {"tool_name": "TaskCreate", "tool_input": {}}, str(tmp_path)) == 2
-
-    def test_agent_team_allows(self, tmp_path: Path) -> None:
-        _make_mission(tmp_path, mode="agent-team")
-        assert _run(cmd_mode_check, {"tool_name": "TaskCreate", "tool_input": {}}, str(tmp_path)) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes the `PreToolUse:TaskCreate` `mode-check` hook that blanket-rejected `TaskCreate` whenever mode ≠ `agent-team`, blocking the admiral from creating its own Ctrl+T visibility task list in `subagents` mode (the dominant Nelson mode).
- The hook payload provides no field to distinguish admiral from captain, so it could not honor the documented **admiral exception** in `references/tool-mapping.md` and `references/standing-orders/wrong-ensign.md`. Result: a hook directly contradicting the docs, as reported in #112.
- Relaxes enforcement to match the docs: keep the admiral exception, rely on the SKILL.md convention for captain discipline (captain `TaskCreate` in an isolated subagent context never reaches the admiral's Ctrl+T view, so misuse is harmless).

## Changes

- `hooks/hooks.json` — drop the `TaskCreate` matcher block.
- `hooks/nelson_hooks.py` — delete `cmd_mode_check`, its subparser, its dispatch entry, and the `mode-check` line from the module docstring.
- `hooks/test_nelson_hooks.py` — delete the `TestModeCheck` class and the `cmd_mode_check` import; update the docstring.
- `README.md` — drop the now-stale row from the enforcement-hooks table.

`settings.json` is intentionally left untouched: its `Agent|TeamCreate|TaskCreate` matcher invokes `nelson-phase.py validate-tool`, not `nelson_hooks.py mode-check`, and is out of scope.

## Out of scope

- Adding admiral-detection machinery (transcript_path comparison, session markers) — rejected as over-engineering for a documented soft convention.
- Re-enforcing captain discipline via a different mechanism — captain `TaskCreate` in an isolated subagent context is harmless; SKILL.md guidance is sufficient.

## Test plan

- [x] `pytest hooks/test_nelson_hooks.py -q` — 48 passed (was 52; 4 `TestModeCheck` cases removed)
- [x] `pytest skills/nelson/scripts -q` — 278 passed (no regression)
- [x] `bash scripts/check-references.sh` — OK, no broken cross-refs
- [x] Smoke: `echo '{...}' | python3 hooks/nelson_hooks.py mode-check` now exits with `invalid choice: 'mode-check'` (dispatch entry confirmed gone)
- [ ] Manual: in a real `subagents`-mode mission, confirm the admiral can `TaskCreate` for visibility without surfacing `Standing order violation (wrong-ensign)`

Closes #112.