### PR TITLE
feat: one-time GitHub star prompt at Stand Down

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,8 +576,6 @@ We are actively tracking multi-agent developments across these platforms. If you
 
 ## Star History
 
-On a successful Stand Down, Nelson asks once whether you'd like to star the repo on GitHub. The answer is recorded in `~/.nelson/prefs.json` (`{"star_asked": true}`) and the prompt never repeats — across all your Nelson projects. To skip permanently without seeing the prompt: `mkdir -p ~/.nelson && echo '{"star_asked": true}' > ~/.nelson/prefs.json`.
-
 <a href="https://star-history.com/#harrymunro/nelson&Date">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=harrymunro/nelson&type=Date&theme=dark" />
@@ -585,6 +583,10 @@ On a successful Stand Down, Nelson asks once whether you'd like to star the repo
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=harrymunro/nelson&type=Date" width="600" />
  </picture>
 </a>
+
+### How the star prompt works
+
+On a successful Stand Down, Nelson asks once whether you'd like to star the repo on GitHub. The answer is recorded in `~/.nelson/prefs.json` (`{"star_asked": true}`) and the prompt never repeats — across all your Nelson projects. To skip permanently without seeing the prompt: `mkdir -p ~/.nelson && echo '{"star_asked": true}' > ~/.nelson/prefs.json`.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -576,6 +576,8 @@ We are actively tracking multi-agent developments across these platforms. If you
 
 ## Star History
 
+On a successful Stand Down, Nelson asks once whether you'd like to star the repo on GitHub. The answer is recorded in `~/.nelson/prefs.json` (`{"star_asked": true}`) and the prompt never repeats — across all your Nelson projects. To skip permanently without seeing the prompt: `mkdir -p ~/.nelson && echo '{"star_asked": true}' > ~/.nelson/prefs.json`.
+
 <a href="https://star-history.com/#harrymunro/nelson&Date">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=harrymunro/nelson&type=Date&theme=dark" />

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -329,20 +329,44 @@ Reference `references/admiralty-templates/captains-log.md` for the captain's log
 
 **Mission Complete Gate:** You MUST NOT declare the mission complete until `{mission-dir}/captains-log.md` exists on disk and has been confirmed readable. If context pressure is high, write a minimal log noting which sections were abbreviated — but the file must exist. Skipping Step 8 is never permitted.
 
-**GitHub Star Prompt (one-time, success only):** After the Mission Complete Gate passes, and only on a successful mission (`--outcome-achieved` was passed to `nelson-data.py stand-down`), ask the user once whether they would like to star the Nelson repo. Skip silently if `gh auth status` exits non-zero or if `~/.nelson/prefs.json` already has `"star_asked": true`.
+**GitHub Star Prompt (one-time, success only):** After the Mission Complete Gate passes, ask the user once whether they would like to star the Nelson repo (canonical slug `harrymunro/nelson`). Run all three preflight checks below; if any prints `SKIP`, skip the prompt silently and finish Stand Down.
 
 ```bash
-gh auth status &>/dev/null && echo "GH_OK" || echo "GH_MISSING"
-python3 -c "import json,os; p=os.path.expanduser('~/.nelson/prefs.json'); print((json.load(open(p)) if os.path.exists(p) else {}).get('star_asked'))"
+gh auth status &>/dev/null && echo "GH_OK" || echo "SKIP_NO_GH"
+python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.nelson/prefs.json')
+prefs = {}
+if os.path.exists(path):
+    try:
+        with open(path, encoding='utf-8') as f:
+            loaded = json.load(f)
+        if isinstance(loaded, dict):
+            prefs = loaded
+    except Exception:
+        prefs = {}
+print("SKIP_ALREADY_ASKED" if prefs.get('star_asked') is True else "PREFS_OK")
+PY
+python3 - <<'PY'
+import json, os, sys
+mission_dir = os.environ.get('MISSION_DIR', '{mission-dir}')
+sd_path = os.path.join(mission_dir, 'stand-down.json')
+try:
+    with open(sd_path, encoding='utf-8') as f:
+        sd = json.load(f)
+    print("OUTCOME_OK" if sd.get('outcome_achieved') is True else "SKIP_OUTCOME_NOT_ACHIEVED")
+except Exception:
+    print("SKIP_NO_STAND_DOWN")
+PY
 ```
 
-If both checks pass (gh authed, `star_asked` not `True`), invoke `AskUserQuestion` with:
+Substitute `{mission-dir}` with the actual mission directory path (or export `MISSION_DIR` first). If all three lines are `GH_OK`, `PREFS_OK`, `OUTCOME_OK`, invoke `AskUserQuestion` with:
 
 - **Question:** "Nelson helped finish that mission. Would you star the repo on GitHub?"
 - **Star Nelson** — "Helps the project grow."
 - **Maybe later** — "Skip for now (won't ask again)."
 
-On **Star Nelson**, run `gh api -X PUT /user/starred/harrymunro/nelson`. If the call fails, print `Couldn't reach GitHub — try 'gh api -X PUT /user/starred/harrymunro/nelson' manually.` and continue. Never let this step block Stand Down.
+On **Star Nelson**, run `gh api -X PUT /user/starred/harrymunro/nelson` (idempotent — returns 204 whether or not the repo is already starred). If the call fails, print `Couldn't reach GitHub — try 'gh api -X PUT /user/starred/harrymunro/nelson' manually.` and continue. Never let this step block Stand Down.
 
 On any answer (including a custom "Other" response), set `star_asked: true` in `~/.nelson/prefs.json`, preserving any existing keys:
 

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -329,6 +329,44 @@ Reference `references/admiralty-templates/captains-log.md` for the captain's log
 
 **Mission Complete Gate:** You MUST NOT declare the mission complete until `{mission-dir}/captains-log.md` exists on disk and has been confirmed readable. If context pressure is high, write a minimal log noting which sections were abbreviated — but the file must exist. Skipping Step 8 is never permitted.
 
+**GitHub Star Prompt (one-time, success only):** After the Mission Complete Gate passes, and only on a successful mission (`--outcome-achieved` was passed to `nelson-data.py stand-down`), ask the user once whether they would like to star the Nelson repo. Skip silently if `gh auth status` exits non-zero or if `~/.nelson/prefs.json` already has `"star_asked": true`.
+
+```bash
+gh auth status &>/dev/null && echo "GH_OK" || echo "GH_MISSING"
+python3 -c "import json,os; p=os.path.expanduser('~/.nelson/prefs.json'); print((json.load(open(p)) if os.path.exists(p) else {}).get('star_asked'))"
+```
+
+If both checks pass (gh authed, `star_asked` not `True`), invoke `AskUserQuestion` with:
+
+- **Question:** "Nelson helped finish that mission. Would you star the repo on GitHub?"
+- **Star Nelson** — "Helps the project grow."
+- **Maybe later** — "Skip for now (won't ask again)."
+
+On **Star Nelson**, run `gh api -X PUT /user/starred/harrymunro/nelson`. If the call fails, print `Couldn't reach GitHub — try 'gh api -X PUT /user/starred/harrymunro/nelson' manually.` and continue. Never let this step block Stand Down.
+
+On any answer (including a custom "Other" response), set `star_asked: true` in `~/.nelson/prefs.json`, preserving any existing keys:
+
+```bash
+python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.nelson/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs['star_asked'] = True
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+```
+
+This is a single ask per user across all Nelson projects. Either answer locks the prompt forever.
+
 ## Standing Orders
 
 Consult the specific standing order that matches the situation.


### PR DESCRIPTION
## Summary

- Adds a single, one-time GitHub star prompt to Step 8 (Stand Down) that fires only on a successful mission, after the Mission Complete Gate.
- Pattern mirrors [Q00/ouroboros](https://github.com/Q00/ouroboros): a pure markdown directive in `SKILL.md` — no new Python module, subcommand, event type, or test surface.
- Persists `{"star_asked": true}` in `~/.nelson/prefs.json` so the prompt is one-shot per user across all Nelson projects on the same machine.

## Behaviour

The directive tells Claude to:

1. Skip silently if `gh auth status` fails or `~/.nelson/prefs.json["star_asked"]` is already `true`.
2. Otherwise invoke `AskUserQuestion` with two options: **Star Nelson** / **Maybe later**.
3. On **Star Nelson**: run `gh api -X PUT /user/starred/harrymunro/nelson` (idempotent — no pre-check needed). On API failure, print a friendly note and continue; never block Stand Down.
4. On any answer (including a custom "Other" response): merge `star_asked: true` into prefs via inline `python3 -<<'PY'` heredoc, preserving any existing keys.

## Out of scope (deferred per issue notes)

- Re-asking after N missions on "Maybe later".
- Configurable `NELSON_NO_STAR_PROMPT` env var (manual workaround documented in README).
- `/nelson-star` slash command.
- Mission-log telemetry beyond the local prefs flag.

## Test plan

- [x] `scripts/check-references.sh` passes (no broken cross-references).
- [x] `pytest skills/nelson/scripts/` — 278 tests pass.
- [x] `pytest hooks/` — 52 tests pass.
- [x] Heredoc smoke-tested against a tmp `HOME`: fresh-create, key-preservation merge, read-back idempotency, missing-file branch all behave correctly.
- [ ] Manual QA on a real mission: gh authed + first success → prompt fires, Star Nelson → repo starred, prefs file written.
- [ ] Manual QA: second mission Stand Down → prompt does not re-fire.
- [ ] Manual QA: `gh auth logout` → prompt skipped, Stand Down completes.
- [ ] Manual QA: `outcome_achieved=false` → prompt skipped.

Closes nelson-4yt.