### PR TITLE
feat: restore TaskCreate captain-misuse enforcement via admiral session marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,11 @@ Nelson is not purely advisory. A set of Claude Code hooks (`hooks/nelson_hooks.p
 | Event | Hook | What it enforces |
 |---|---|---|
 | `PreToolUse` on `Agent` | `preflight` | Station tier gate, file ownership conflicts, mode-tool consistency |
+| `PreToolUse` on `TaskCreate` | `session-check` | Captain TaskCreate gate (admiral exception via session marker) |
 | `PostToolUse` on `Write`/`Edit` | `brief-validate` | Turnover brief quality gate |
 | `TaskCompleted` | `task-complete` | Validation evidence and station controls |
 | `TeammateIdle` | `idle-ship` | Paid-off standing order advisory |
+| `SessionStart` | `session-init` | Records admiral `transcript_path` for the TaskCreate gate |
 
 Plugin installs auto-discover `hooks/hooks.json` and wire these up with no user action. Hooks degrade gracefully: if no active Nelson mission is found, they exit cleanly and do not interfere with non-Nelson workflows. See [Installation](#installation) for manual-install caveats.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/nelson_hooks.py\" session-init"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Agent",
@@ -7,6 +17,15 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/nelson_hooks.py\" preflight"
+          }
+        ]
+      },
+      {
+        "matcher": "TaskCreate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/nelson_hooks.py\" session-check"
           }
         ]
       }

--- a/hooks/nelson_hooks.py
+++ b/hooks/nelson_hooks.py
@@ -42,6 +42,8 @@ from typing import Any, NoReturn
 
 
 ADMIRAL_SESSION_MARKER = "admiral.session"
+# NOTE: must stay in sync with
+# skills/nelson/scripts/nelson_data_utils.py:ADMIRAL_SESSION_MARKER.
 
 
 def _read_stdin() -> dict[str, Any]:
@@ -687,19 +689,23 @@ def cmd_session_init(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
+CAPTAIN_GATED_MODES = frozenset({"subagents", "single-session"})
+
+
 def cmd_session_check(args: argparse.Namespace) -> None:
     """PreToolUse:TaskCreate gate using admiral session marker.
 
-    Allows TaskCreate when:
-      - no active Nelson mission (graceful degradation)
-      - mode is agent-team (TaskCreate is the shared coordination surface)
-      - admiral.session marker missing (fail-open, never had a chance to record)
-      - payload transcript_path matches the marker (admiral)
-      - payload transcript_path missing (defensive fail-open)
+    Rejects with wrong-ensign violation only when mode is in
+    CAPTAIN_GATED_MODES (subagents, single-session) AND the payload
+    transcript_path does not match the recorded admiral transcript
+    (i.e. captain subagent context).
 
-    Rejects with wrong-ensign violation only when mode is subagents or
-    single-session AND the payload transcript_path does not match the
-    recorded admiral transcript (i.e. captain subagent context).
+    Fails open in every other case:
+      - no active Nelson mission (graceful degradation)
+      - mode not in CAPTAIN_GATED_MODES (agent-team, future modes)
+      - admiral.session marker missing (never had a chance to record)
+      - admiral.session marker empty (interrupted write)
+      - payload transcript_path missing (defensive)
     """
     payload = _read_stdin()
     ctx = _load_mission_context(payload)
@@ -708,7 +714,7 @@ def cmd_session_check(args: argparse.Namespace) -> None:
 
     _, battle_plan = ctx
     mode = _get_mode(battle_plan)
-    if mode == "agent-team":
+    if mode not in CAPTAIN_GATED_MODES:
         _allow()
 
     nelson_dir = Path(payload.get("cwd", ".")) / ".nelson"
@@ -719,6 +725,9 @@ def cmd_session_check(args: argparse.Namespace) -> None:
     try:
         admiral_transcript = marker.read_text(encoding="utf-8").strip()
     except OSError:
+        _allow()
+
+    if not admiral_transcript:
         _allow()
 
     payload_transcript = payload.get("transcript_path", "").strip()

--- a/hooks/nelson_hooks.py
+++ b/hooks/nelson_hooks.py
@@ -10,6 +10,11 @@ hooks. Each subcommand maps to a hook event type:
   brief-validate — PostToolUse on Write/Edit: turnover brief quality gate
   task-complete  — TaskCompleted: validation evidence and station controls
   idle-ship      — TeammateIdle: paid-off standing order advisory
+  session-init   — SessionStart: record admiral transcript_path for the
+                   TaskCreate captain-misuse gate
+  session-check  — PreToolUse on TaskCreate: reject captain TaskCreate calls
+                   in subagents/single-session mode (admiral exception via
+                   the marker written by session-init)
 
 Exit codes:
   0 — allow (action proceeds)
@@ -34,6 +39,9 @@ from typing import Any, NoReturn
 # ---------------------------------------------------------------------------
 # Shared utilities
 # ---------------------------------------------------------------------------
+
+
+ADMIRAL_SESSION_MARKER = "admiral.session"
 
 
 def _read_stdin() -> dict[str, Any]:
@@ -114,6 +122,25 @@ def _load_mission_context(
     if not bp:
         return None
     return mission_dir, bp
+
+
+def _write_admiral_marker(nelson_dir: Path, transcript_path: str) -> bool:
+    """Write the admiral session marker. Returns True on success, False on failure.
+
+    The marker stores the admiral's transcript_path so cmd_session_check can
+    distinguish admiral calls (match) from captain subagent calls (mismatch).
+    """
+    if not nelson_dir.is_dir():
+        return False
+    if not transcript_path.strip():
+        return False
+    try:
+        (nelson_dir / ADMIRAL_SESSION_MARKER).write_text(
+            transcript_path.strip() + "\n", encoding="utf-8",
+        )
+        return True
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +235,14 @@ def cmd_preflight(args: argparse.Namespace) -> None:
     _, battle_plan = ctx
     tasks = _get_tasks(battle_plan)
     tool_input = payload.get("tool_input", {})
+
+    # Opportunistic admiral marker backfill: if init ran after SessionStart,
+    # the marker won't have been written. The admiral always fires PreToolUse
+    # on Agent before spawning captains, so this is a safe write point.
+    nelson_dir = Path(payload.get("cwd", ".")) / ".nelson"
+    marker = nelson_dir / ADMIRAL_SESSION_MARKER
+    if not marker.is_file():
+        _write_admiral_marker(nelson_dir, payload.get("transcript_path", ""))
 
     for check in (
         lambda: _check_station_tiers(tasks),
@@ -628,6 +663,77 @@ def _clear_idle_tracker(mission_dir: Path, ship_name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: session-init (SessionStart)
+# ---------------------------------------------------------------------------
+
+
+def cmd_session_init(args: argparse.Namespace) -> None:
+    """SessionStart event: record admiral identity for TaskCreate enforcement.
+
+    Writes the payload's transcript_path to .nelson/admiral.session so the
+    PreToolUse:TaskCreate hook can distinguish admiral (match) from captain
+    subagents (mismatch). No-op when .nelson/ does not yet exist — non-Nelson
+    projects are unaffected, and Nelson projects whose mission has not been
+    initialised will be backfilled by cmd_preflight on the first Agent spawn.
+    """
+    payload = _read_stdin()
+    cwd = Path(payload.get("cwd", "."))
+    _write_admiral_marker(cwd / ".nelson", payload.get("transcript_path", ""))
+    _allow()
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: session-check (PreToolUse on TaskCreate)
+# ---------------------------------------------------------------------------
+
+
+def cmd_session_check(args: argparse.Namespace) -> None:
+    """PreToolUse:TaskCreate gate using admiral session marker.
+
+    Allows TaskCreate when:
+      - no active Nelson mission (graceful degradation)
+      - mode is agent-team (TaskCreate is the shared coordination surface)
+      - admiral.session marker missing (fail-open, never had a chance to record)
+      - payload transcript_path matches the marker (admiral)
+      - payload transcript_path missing (defensive fail-open)
+
+    Rejects with wrong-ensign violation only when mode is subagents or
+    single-session AND the payload transcript_path does not match the
+    recorded admiral transcript (i.e. captain subagent context).
+    """
+    payload = _read_stdin()
+    ctx = _load_mission_context(payload)
+    if ctx is None:
+        _allow()
+
+    _, battle_plan = ctx
+    mode = _get_mode(battle_plan)
+    if mode == "agent-team":
+        _allow()
+
+    nelson_dir = Path(payload.get("cwd", ".")) / ".nelson"
+    marker = nelson_dir / ADMIRAL_SESSION_MARKER
+    if not marker.is_file():
+        _allow()
+
+    try:
+        admiral_transcript = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        _allow()
+
+    payload_transcript = payload.get("transcript_path", "").strip()
+    if payload_transcript and payload_transcript != admiral_transcript:
+        _reject(
+            "Standing order violation (wrong-ensign): "
+            f"TaskCreate is reserved for the admiral in {mode} mode. "
+            "Captains report progress via Agent return value, not the task list. "
+            "See references/tool-mapping.md."
+        )
+
+    _allow()
+
+
+# ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
 
@@ -655,6 +761,14 @@ def main() -> None:
         "idle-ship",
         help="Idle ship advisory (TeammateIdle)",
     )
+    subparsers.add_parser(
+        "session-init",
+        help="Record admiral transcript_path on session start",
+    )
+    subparsers.add_parser(
+        "session-check",
+        help="Captain TaskCreate gate (PreToolUse on TaskCreate)",
+    )
 
     args = parser.parse_args()
 
@@ -663,6 +777,8 @@ def main() -> None:
         "brief-validate": cmd_brief_validate,
         "task-complete": cmd_task_complete,
         "idle-ship": cmd_idle_ship,
+        "session-init": cmd_session_init,
+        "session-check": cmd_session_check,
     }
 
     handler = dispatch.get(args.command)

--- a/hooks/test_nelson_hooks.py
+++ b/hooks/test_nelson_hooks.py
@@ -24,6 +24,7 @@ if hooks_dir not in sys.path:
 
 from conftest import VALID_FLAGSHIP_BRIEF, VALID_STANDARD_BRIEF  # noqa: E402
 from nelson_hooks import (  # noqa: E402
+    ADMIRAL_SESSION_MARKER,
     ROLLBACK_PATTERNS,
     VALIDATION_EVIDENCE_PATTERNS,
     _check_running_plot_nonempty,
@@ -35,6 +36,8 @@ from nelson_hooks import (  # noqa: E402
     cmd_brief_validate,
     cmd_idle_ship,
     cmd_preflight,
+    cmd_session_check,
+    cmd_session_init,
     cmd_task_complete,
 )
 
@@ -502,3 +505,150 @@ class TestIdleShip:
         _make_mission(tmp_path, fleet_status={"squadron": []})
         _run(cmd_idle_ship, {"teammate_name": "HMS Unknown"}, str(tmp_path))
         assert "not found" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Session-init (SessionStart)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionInit:
+    def test_no_nelson_dir_allows_and_no_write(self, tmp_path: Path) -> None:
+        """Non-Nelson project: no .nelson/ exists, hook is a no-op (allow)."""
+        code = _run(
+            cmd_session_init,
+            {"transcript_path": "/tmp/x.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+        assert not (tmp_path / ".nelson" / ADMIRAL_SESSION_MARKER).exists()
+
+    def test_writes_admiral_session_marker(self, tmp_path: Path) -> None:
+        (tmp_path / ".nelson").mkdir()
+        code = _run(
+            cmd_session_init,
+            {"transcript_path": "/transcripts/admiral.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+        marker = tmp_path / ".nelson" / ADMIRAL_SESSION_MARKER
+        assert marker.is_file()
+        assert marker.read_text(encoding="utf-8").strip() == "/transcripts/admiral.jsonl"
+
+    def test_overwrites_existing_marker_on_session_resume(
+        self, tmp_path: Path,
+    ) -> None:
+        (tmp_path / ".nelson").mkdir()
+        marker = tmp_path / ".nelson" / ADMIRAL_SESSION_MARKER
+        marker.write_text("/old/transcript.jsonl\n", encoding="utf-8")
+        code = _run(
+            cmd_session_init,
+            {"transcript_path": "/new/transcript.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+        assert marker.read_text(encoding="utf-8").strip() == "/new/transcript.jsonl"
+
+    def test_missing_transcript_path_is_no_op(self, tmp_path: Path) -> None:
+        (tmp_path / ".nelson").mkdir()
+        code = _run(cmd_session_init, {}, cwd=str(tmp_path))
+        assert code == 0
+        assert not (tmp_path / ".nelson" / ADMIRAL_SESSION_MARKER).exists()
+
+
+# ---------------------------------------------------------------------------
+# Session-check (PreToolUse on TaskCreate)
+# ---------------------------------------------------------------------------
+
+
+def _write_marker(tmp_path: Path, transcript: str) -> None:
+    """Helper: write the admiral session marker for tests."""
+    nelson_dir = tmp_path / ".nelson"
+    nelson_dir.mkdir(exist_ok=True)
+    (nelson_dir / ADMIRAL_SESSION_MARKER).write_text(
+        transcript + "\n", encoding="utf-8",
+    )
+
+
+class TestSessionCheck:
+    def test_no_mission_allows(self, tmp_path: Path) -> None:
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/captain.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+
+    def test_agent_team_mode_allows(self, tmp_path: Path) -> None:
+        _make_mission(tmp_path, mode="agent-team")
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/captain.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+
+    def test_marker_missing_allows(self, tmp_path: Path) -> None:
+        """Graceful degradation: missing marker means allow."""
+        _make_mission(tmp_path, mode="subagents")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/anyone.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+
+    def test_admiral_match_allows_subagents_mode(self, tmp_path: Path) -> None:
+        _make_mission(tmp_path, mode="subagents")
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/admiral.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+
+    def test_admiral_match_allows_single_session_mode(
+        self, tmp_path: Path,
+    ) -> None:
+        _make_mission(tmp_path, mode="single-session")
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/admiral.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+
+    def test_captain_mismatch_rejects_subagents_mode(
+        self, tmp_path: Path,
+    ) -> None:
+        _make_mission(tmp_path, mode="subagents")
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/captain.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 2
+
+    def test_captain_mismatch_rejects_single_session_mode(
+        self, tmp_path: Path,
+    ) -> None:
+        _make_mission(tmp_path, mode="single-session")
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/captain.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 2
+
+    def test_missing_transcript_path_allows(self, tmp_path: Path) -> None:
+        """Defensive fail-open: payload with no transcript_path is allowed."""
+        _make_mission(tmp_path, mode="subagents")
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(cmd_session_check, {}, cwd=str(tmp_path))
+        assert code == 0

--- a/hooks/test_nelson_hooks.py
+++ b/hooks/test_nelson_hooks.py
@@ -652,3 +652,86 @@ class TestSessionCheck:
         _write_marker(tmp_path, "/admiral.jsonl")
         code = _run(cmd_session_check, {}, cwd=str(tmp_path))
         assert code == 0
+
+    def test_empty_marker_allows(self, tmp_path: Path) -> None:
+        """Empty marker (interrupted write) must fail-open — never reject."""
+        _make_mission(tmp_path, mode="subagents")
+        nelson_dir = tmp_path / ".nelson"
+        (nelson_dir / ADMIRAL_SESSION_MARKER).write_text("", encoding="utf-8")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/admiral.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+
+    def test_unknown_mode_allows(self, tmp_path: Path) -> None:
+        """Unknown/future modes must fail-open: only explicit captain modes gate."""
+        _make_mission(tmp_path, mode="future-mode-xyz")
+        _write_marker(tmp_path, "/admiral.jsonl")
+        code = _run(
+            cmd_session_check,
+            {"transcript_path": "/captain.jsonl"},
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Preflight admiral-marker backfill
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightAdmiralMarkerBackfill:
+    def test_backfill_writes_marker_when_missing(self, tmp_path: Path) -> None:
+        """Preflight backfills admiral marker when SessionStart missed it."""
+        _make_mission(tmp_path, tasks=[
+            {
+                "id": "t1",
+                "name": "Task 1",
+                "owner": "HMS Daring",
+                "station_tier": 1,
+                "file_ownership": ["src/auth.py"],
+            },
+        ])
+        marker = tmp_path / ".nelson" / ADMIRAL_SESSION_MARKER
+        assert not marker.exists()
+        code = _run(
+            cmd_preflight,
+            {
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "general-purpose"},
+                "transcript_path": "/transcripts/admiral.jsonl",
+            },
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+        assert marker.is_file()
+        assert marker.read_text(encoding="utf-8").strip() == "/transcripts/admiral.jsonl"
+
+    def test_backfill_does_not_overwrite_existing_marker(
+        self, tmp_path: Path,
+    ) -> None:
+        """Existing marker is preserved — only writes when missing."""
+        _make_mission(tmp_path, tasks=[
+            {
+                "id": "t1",
+                "name": "Task 1",
+                "owner": "HMS Daring",
+                "station_tier": 1,
+                "file_ownership": ["src/auth.py"],
+            },
+        ])
+        marker = tmp_path / ".nelson" / ADMIRAL_SESSION_MARKER
+        marker.write_text("/original/admiral.jsonl\n", encoding="utf-8")
+        code = _run(
+            cmd_preflight,
+            {
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "general-purpose"},
+                "transcript_path": "/different/path.jsonl",
+            },
+            cwd=str(tmp_path),
+        )
+        assert code == 0
+        assert marker.read_text(encoding="utf-8").strip() == "/original/admiral.jsonl"

--- a/skills/nelson/scripts/nelson_data_lifecycle.py
+++ b/skills/nelson/scripts/nelson_data_lifecycle.py
@@ -26,6 +26,7 @@ from nelson_circuit_breakers import (
 )
 from nelson_data_memory import _update_patterns_store, _update_standing_order_stats
 from nelson_data_utils import (
+    ADMIRAL_SESSION_MARKER,
     FLEET_STATUS_EVENT_TYPES,
     FLEET_STATUS_STALENESS_THRESHOLD_SECONDS,
     JSON_INDENT,
@@ -1030,9 +1031,10 @@ def cmd_stand_down(args: argparse.Namespace) -> None:
         _err(f"Warning: failed to update memory store: {exc}")
 
     # Best-effort cleanup of admiral session marker (mission-scoped lifecycle).
-    # Marker lives at .nelson/admiral.session, two levels up from mission_dir.
+    # Marker lives at .nelson/<ADMIRAL_SESSION_MARKER>, two levels up from
+    # mission_dir (.nelson/missions/<id>/).
     try:
-        (mission_dir.parent.parent / "admiral.session").unlink()
+        (mission_dir.parent.parent / ADMIRAL_SESSION_MARKER).unlink()
     except FileNotFoundError:
         pass
     except OSError:

--- a/skills/nelson/scripts/nelson_data_lifecycle.py
+++ b/skills/nelson/scripts/nelson_data_lifecycle.py
@@ -1029,6 +1029,15 @@ def cmd_stand_down(args: argparse.Namespace) -> None:
     except Exception as exc:
         _err(f"Warning: failed to update memory store: {exc}")
 
+    # Best-effort cleanup of admiral session marker (mission-scoped lifecycle).
+    # Marker lives at .nelson/admiral.session, two levels up from mission_dir.
+    try:
+        (mission_dir.parent.parent / "admiral.session").unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
     # Print mission summary
     achieved = "ACHIEVED" if args.outcome_achieved else "NOT ACHIEVED"
     print(

--- a/skills/nelson/scripts/nelson_data_utils.py
+++ b/skills/nelson/scripts/nelson_data_utils.py
@@ -83,6 +83,10 @@ assert FLEET_STATUS_EVENT_TYPES <= VALID_EVENT_TYPES
 
 FLEET_STATUS_STALENESS_THRESHOLD_SECONDS = 600
 
+# Filename of the admiral session marker, written under .nelson/.
+# Must stay in sync with hooks/nelson_hooks.py:ADMIRAL_SESSION_MARKER.
+ADMIRAL_SESSION_MARKER = "admiral.session"
+
 
 # ---------------------------------------------------------------------------
 # Helpers — pure functions (no side effects)

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -702,6 +702,42 @@ class TestStandDown:
         fs = read_json(mission_dir / "fleet-status.json")
         assert fs["mission"]["status"] == "complete"
 
+    def test_removes_admiral_session_marker(self, tmp_path: Path) -> None:
+        """Admiral session marker is cleaned up at stand-down."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        add_task(mission_dir)
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        marker = tmp_path / ".nelson" / "admiral.session"
+        marker.write_text("/transcripts/admiral.jsonl\n", encoding="utf-8")
+        assert marker.exists()
+        run(
+            "stand-down",
+            "--mission-dir", str(mission_dir),
+            "--outcome-achieved",
+            "--actual-outcome", "Done",
+            "--metric-result", "Pass",
+        )
+        assert not marker.exists()
+
+    def test_stand_down_succeeds_without_admiral_session_marker(
+        self, tmp_path: Path,
+    ) -> None:
+        """Cleanup is best-effort: missing marker must not fail stand-down."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        add_task(mission_dir)
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        marker = tmp_path / ".nelson" / "admiral.session"
+        assert not marker.exists()
+        run(
+            "stand-down",
+            "--mission-dir", str(mission_dir),
+            "--outcome-achieved",
+            "--actual-outcome", "Done",
+            "--metric-result", "Pass",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Status


### PR DESCRIPTION
## Summary

Restores the captain-`TaskCreate` enforcement that PR #116 removed, this time without false-positive rejections of the admiral's own Ctrl+T visibility tracking. Discriminates admiral from captain subagents via the hook payload's `transcript_path` (each subagent spawn gets a fresh transcript; admiral keeps its own).

- `session-init` (SessionStart): records admiral `transcript_path` to `.nelson/admiral.session`.
- `session-check` (PreToolUse on `TaskCreate`): rejects with `wrong-ensign` only in `subagents` / `single-session` mode when the payload `transcript_path` does not match the recorded admiral marker.
- `preflight`: opportunistically backfills the marker if `init` ran after SessionStart fired (admiral always spawns Agents, so this is the safe fallback).
- `stand-down`: best-effort marker cleanup.
- Every uncertainty path fails open (no mission, missing marker, missing/empty `transcript_path`), so non-Nelson projects and edge cases stay untouched.

> **Depends on #116** — this branch is based off `fix/issue-112-taskcreate-hook-removal`. The new hook reuses the `PreToolUse:TaskCreate` matcher slot that #116 frees up; otherwise both `mode-check` and `session-check` would fire and the buggy mode-check would still block the admiral. If #116 lands first, retarget this PR to `main` (no overlap on changed lines).

Tracks `nelson-1o9`.

## Test plan

- [x] `pytest hooks/test_nelson_hooks.py -q` → 60/60 pass (was 48; +4 `TestSessionInit`, +8 `TestSessionCheck`).
- [x] `pytest skills/nelson/scripts -q` → 280/280 pass (was 278; +2 stand-down marker-cleanup tests).
- [x] `bash scripts/check-references.sh` → all cross-references valid.
- [x] `python3 hooks/nelson_hooks.py --help` → both new subcommands listed.
- [x] Manual stdin smoke tests for `session-init`: writes marker when `.nelson/` exists, no-op when it doesn't.
- [ ] **Discriminator spike** (verification, not yet run): start a `subagents`-mode Nelson mission, spawn a captain via `Agent`, log payloads from a throwaway `PreToolUse:TaskCreate` hook, confirm captain `transcript_path` differs from admiral. Plan called for this before committing — flagging for reviewer because it requires a real mission run.
- [ ] **Real-mission smoke test**: admiral `TaskCreate` allowed without `wrong-ensign` feedback; captain `TaskCreate` rejected; `.nelson/admiral.session` removed at stand-down; `SessionStart` is a no-op in non-Nelson projects.

## Notes

- Marker location: `.nelson/admiral.session`, project-scoped (not mission-scoped). Stand-down resolves it via `mission_dir.parent.parent`.
- README enforcement-hooks table re-adds the `TaskCreate` row plus a new `SessionStart` row.
- No changes to `references/tool-mapping.md` or `references/standing-orders/wrong-ensign.md` — existing admiral-exception language remains accurate.