### PR TITLE
feat: learn standing orders from mission patterns (#87)

### DIFF
--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -393,7 +393,7 @@ This is a single ask per user across all Nelson projects. Either answer locks th
 
 ## Standing Orders
 
-Consult the specific standing order that matches the situation.
+Consult the specific standing order that matches the situation. The library is empirically extensible: see `scripts/nelson_data_patterns.py` for the promotion workflow that mines new candidate orders from mission patterns and surfaces them for human review.
 
 | Situation | Standing Order |
 |---|---|

--- a/skills/nelson/references/structured-data.md
+++ b/skills/nelson/references/structured-data.md
@@ -323,6 +323,68 @@ python3 .claude/skills/nelson/scripts/nelson-data.py analytics \
   --metric all --json --last 10
 ```
 
+### `detect-patterns` — Mine candidate standing orders (read/write memory)
+
+Run after a mission stand-down (and after `index`) to surface anti-patterns that recur across the fleet. The detector clusters `avoid` texts, scores each cluster with Fisher's exact + log-odds against mission outcomes, drops anything resembling an existing standing order or a previously dismissed candidate, requires a negative correlation with success (anti-patterns only — not patterns that correlate with wins), and appends survivors to the candidate queue for human review. No standing orders are written or modified by this command — promotion is always a separate, human-initiated step.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py detect-patterns \
+  --missions-dir .nelson/missions
+```
+
+Arguments:
+
+- `--missions-dir` — Missions directory. Memory dir is derived as `{missions_dir}/../memory` (matches `brief`).
+- `--memory-dir` — Override the derived memory directory.
+- `--standing-orders-dir` — Where to scan for existing orders during the novelty filter. Defaults to the skill's `references/standing-orders/`.
+- `--min-missions N` — Minimum recorded missions before detection runs (default 10).
+- `--confidence-threshold F` — Drop candidates whose `1 - p_value` is below this (default 0.7).
+- `--json` — Emit a JSON `{status, detected, queue_size, memory_dir}` summary on stdout instead of free text. Useful for CI gates that want to fail on new high-confidence candidates.
+
+Output: appends to `{memory_dir}/candidate-standing-orders.json`. On a first run with zero candidates the queue file is not created, to avoid littering the memory dir.
+
+### `promote-candidate` — Promote a candidate to a standing order
+
+Promote writes a new `.md` under the standing-orders directory, inserts a row into the SKILL.md Standing Orders lookup table, and removes the candidate from the pending queue. Promotion is transactional: if any step fails the previous step is rolled back so the repo does not end up with an orphan `.md` or a half-edited SKILL.md.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py promote-candidate \
+  --candidate-id cand-abc123 \
+  --missions-dir .nelson/missions
+```
+
+Arguments:
+
+- `--candidate-id` (required) — The candidate's id from the queue.
+- `--missions-dir` / `--memory-dir` — Same resolution rules as `detect-patterns`.
+
+Failure modes (exit 1, message on stderr):
+
+- Candidate id not found in the queue.
+- A standing order with the same title already exists (refuses to overwrite hand-written orders).
+- SKILL.md is missing, or its `## Standing Orders` heading / lookup table cannot be located.
+
+The title is re-slugified at the promotion boundary so a hand-edited queue entry cannot escape the standing-orders directory via path traversal. Free-text fields are sanitised before being written into the SKILL.md table cell.
+
+### `dismiss-candidate` — Archive a candidate so it is not re-proposed
+
+Move a candidate to the dismissed archive. Subsequent `detect-patterns` runs will not re-surface the same fingerprint, so reviewers are not asked the same question twice.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py dismiss-candidate \
+  --candidate-id cand-abc123 \
+  --reason "duplicate of split-keel" \
+  --missions-dir .nelson/missions
+```
+
+Arguments:
+
+- `--candidate-id` (required).
+- `--reason` (required) — Free text recorded in the archive for future reference.
+- `--missions-dir` / `--memory-dir` — Same resolution rules as `detect-patterns`.
+
+Output: writes `{memory_dir}/dismissed-candidates.json`.
+
 ## Phase Engine
 
 The `nelson-phase.py` script manages the deterministic phase engine. It enforces phase transitions with defined entry/exit criteria and validates phase-appropriate tool usage via PreToolUse hooks.

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -45,6 +45,13 @@ from nelson_data_lifecycle import (
     cmd_status,
     cmd_task,
 )
+from nelson_data_patterns import (
+    DEFAULT_CONFIDENCE_THRESHOLD,
+    DEFAULT_MIN_MISSIONS,
+    cmd_detect_patterns,
+    cmd_dismiss_candidate,
+    cmd_promote_candidate,
+)
 from nelson_data_utils import (
     VALID_ESTIMATE_OUTCOME_METHODS,
     VALID_ESTIMATE_OUTCOME_STATUSES,
@@ -403,6 +410,66 @@ def build_parser() -> argparse.ArgumentParser:
         "--last", type=int, default=0, help="Limit to last N missions (0=all)"
     )
 
+    # --- detect-patterns ---
+    p_dp = subs.add_parser(
+        "detect-patterns",
+        help="Detect candidate standing orders from mission patterns",
+    )
+    p_dp.add_argument(
+        "--memory-dir",
+        default=None,
+        help="Memory directory (default: .nelson/memory)",
+    )
+    p_dp.add_argument(
+        "--standing-orders-dir",
+        default=None,
+        help="Standing orders directory (default: skill references dir)",
+    )
+    p_dp.add_argument(
+        "--min-missions",
+        type=int,
+        default=DEFAULT_MIN_MISSIONS,
+        help=f"Minimum missions before detection runs (default: {DEFAULT_MIN_MISSIONS})",
+    )
+    p_dp.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=DEFAULT_CONFIDENCE_THRESHOLD,
+        help=(
+            "Drop candidates below this confidence "
+            f"(default: {DEFAULT_CONFIDENCE_THRESHOLD})"
+        ),
+    )
+
+    # --- promote-candidate ---
+    p_pc = subs.add_parser(
+        "promote-candidate",
+        help="Promote a candidate to a real standing order",
+    )
+    p_pc.add_argument("candidate_id", help="Candidate ID (e.g. cand-abc123)")
+    p_pc.add_argument(
+        "--memory-dir",
+        default=None,
+        help="Memory directory (default: .nelson/memory)",
+    )
+
+    # --- dismiss-candidate ---
+    p_dc = subs.add_parser(
+        "dismiss-candidate",
+        help="Dismiss a candidate (archived so it is not re-proposed)",
+    )
+    p_dc.add_argument("candidate_id", help="Candidate ID (e.g. cand-abc123)")
+    p_dc.add_argument(
+        "--reason",
+        required=True,
+        help="Why this candidate is being dismissed",
+    )
+    p_dc.add_argument(
+        "--memory-dir",
+        default=None,
+        help="Memory directory (default: .nelson/memory)",
+    )
+
     return parser
 
 
@@ -442,6 +509,9 @@ def main() -> None:
         "history": lambda: cmd_history(args),
         "brief": lambda: cmd_brief(args),
         "analytics": lambda: cmd_analytics(args),
+        "detect-patterns": lambda: cmd_detect_patterns(args),
+        "promote-candidate": lambda: cmd_promote_candidate(args),
+        "dismiss-candidate": lambda: cmd_dismiss_candidate(args),
     }
 
     handler = dispatch.get(args.command)

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -416,9 +416,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Detect candidate standing orders from mission patterns",
     )
     p_dp.add_argument(
+        "--missions-dir",
+        default=None,
+        help="Missions directory (memory dir derived as {missions_dir}/../memory)",
+    )
+    p_dp.add_argument(
         "--memory-dir",
         default=None,
-        help="Memory directory (default: .nelson/memory)",
+        help="Memory directory (overrides --missions-dir derivation)",
     )
     p_dp.add_argument(
         "--standing-orders-dir",
@@ -440,17 +445,33 @@ def build_parser() -> argparse.ArgumentParser:
             f"(default: {DEFAULT_CONFIDENCE_THRESHOLD})"
         ),
     )
+    p_dp.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Emit a JSON summary to stdout instead of a free-text message",
+    )
 
     # --- promote-candidate ---
     p_pc = subs.add_parser(
         "promote-candidate",
         help="Promote a candidate to a real standing order",
     )
-    p_pc.add_argument("candidate_id", help="Candidate ID (e.g. cand-abc123)")
+    p_pc.add_argument(
+        "--candidate-id",
+        dest="candidate_id",
+        required=True,
+        help="Candidate ID (e.g. cand-abc123)",
+    )
+    p_pc.add_argument(
+        "--missions-dir",
+        default=None,
+        help="Missions directory (memory dir derived as {missions_dir}/../memory)",
+    )
     p_pc.add_argument(
         "--memory-dir",
         default=None,
-        help="Memory directory (default: .nelson/memory)",
+        help="Memory directory (overrides --missions-dir derivation)",
     )
 
     # --- dismiss-candidate ---
@@ -458,16 +479,26 @@ def build_parser() -> argparse.ArgumentParser:
         "dismiss-candidate",
         help="Dismiss a candidate (archived so it is not re-proposed)",
     )
-    p_dc.add_argument("candidate_id", help="Candidate ID (e.g. cand-abc123)")
+    p_dc.add_argument(
+        "--candidate-id",
+        dest="candidate_id",
+        required=True,
+        help="Candidate ID (e.g. cand-abc123)",
+    )
     p_dc.add_argument(
         "--reason",
         required=True,
         help="Why this candidate is being dismissed",
     )
     p_dc.add_argument(
+        "--missions-dir",
+        default=None,
+        help="Missions directory (memory dir derived as {missions_dir}/../memory)",
+    )
+    p_dc.add_argument(
         "--memory-dir",
         default=None,
-        help="Memory directory (default: .nelson/memory)",
+        help="Memory directory (overrides --missions-dir derivation)",
     )
 
     return parser

--- a/skills/nelson/scripts/nelson_data_fleet.py
+++ b/skills/nelson/scripts/nelson_data_fleet.py
@@ -559,7 +559,10 @@ def cmd_brief(args: argparse.Namespace) -> None:
 
     try:
         candidate_count = count_pending_candidates(memory_dir)
-    except Exception as exc:  # noqa: BLE001 - brief must never crash
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        # Narrow catch: IO and JSON errors are the realistic failure modes for
+        # a corrupt or unreadable queue.  Other exceptions are unexpected and
+        # should propagate so they surface in tests.
         _err(f"Warning: could not read candidate queue: {exc}")
         candidate_count = 0
 

--- a/skills/nelson/scripts/nelson_data_fleet.py
+++ b/skills/nelson/scripts/nelson_data_fleet.py
@@ -19,6 +19,7 @@ from nelson_data_memory import (
     _find_completed_missions,
     _sync_memory_from_index,
 )
+from nelson_data_patterns import count_pending_candidates
 from nelson_data_utils import (
     JSON_INDENT,
     VALID_ESTIMATE_OUTCOME_METHODS,
@@ -384,6 +385,7 @@ def _build_intelligence_brief(
     stats: dict,
     index_missions: list[dict],
     context: str,
+    candidate_standing_orders: int = 0,
 ) -> dict:
     """Build a structured intelligence brief from memory store data.
 
@@ -457,6 +459,7 @@ def _build_intelligence_brief(
         "top_avoid": [{"pattern": p, "count": c} for p, c in top_avoid],
         "standing_order_hot_spots": hot_spots,
         "precedents": precedents,
+        "candidate_standing_orders": candidate_standing_orders,
     }
 
 
@@ -478,6 +481,13 @@ def _format_brief_text(brief: dict, context: str) -> str:
     if total == 0:
         lines.append("  No mission data available.")
         return "\n".join(lines)
+
+    cso = brief.get("candidate_standing_orders", 0)
+    if cso > 0:
+        lines.append(
+            f"CANDIDATE STANDING ORDERS (awaiting review): {cso}"
+        )
+        lines.append("")
 
     # Patterns to adopt
     top_adopt = brief.get("top_adopt", [])
@@ -547,7 +557,19 @@ def cmd_brief(args: argparse.Namespace) -> None:
 
     stats = _read_json_optional(memory_dir / "standing-order-stats.json") or {}
 
-    brief = _build_intelligence_brief(patterns, stats, index_missions, context)
+    try:
+        candidate_count = count_pending_candidates(memory_dir)
+    except Exception as exc:  # noqa: BLE001 - brief must never crash
+        _err(f"Warning: could not read candidate queue: {exc}")
+        candidate_count = 0
+
+    brief = _build_intelligence_brief(
+        patterns,
+        stats,
+        index_missions,
+        context,
+        candidate_standing_orders=candidate_count,
+    )
 
     if args.json_output:
         print(json.dumps(brief, indent=JSON_INDENT))

--- a/skills/nelson/scripts/nelson_data_patterns.py
+++ b/skills/nelson/scripts/nelson_data_patterns.py
@@ -36,6 +36,9 @@ from math import exp, lgamma, log
 from pathlib import Path
 from typing import Callable
 
+import os
+import tempfile
+
 from nelson_data_utils import (
     _die,
     _err,
@@ -44,6 +47,27 @@ from nelson_data_utils import (
     _read_json_optional,
     _write_json,
 )
+
+
+def _write_text_atomic(path: Path, content: str) -> None:
+    """Write text atomically via tempfile + os.replace.
+
+    Matches the durability properties of ``_write_json`` for non-JSON files
+    (SKILL.md, rendered standing orders) so a crash mid-write cannot leave a
+    torn file behind.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # Type alias for FM synthesis client. Receives a prompt, returns response text
@@ -152,8 +176,19 @@ class Candidate:
 # ---------------------------------------------------------------------------
 
 
+def _default_missions_dir() -> Path:
+    return Path(".nelson/missions")
+
+
 def _default_memory_dir() -> Path:
-    return Path(".nelson/memory")
+    """Default memory dir derived the same way sibling modules derive theirs.
+
+    Matches ``nelson_data_memory._resolve_memory_dir`` and ``cmd_brief``:
+    ``{missions_dir}/../memory``. Without this consistency, ``detect-patterns``
+    would write a queue that ``brief`` could not see under a non-default
+    ``--missions-dir``.
+    """
+    return _default_missions_dir().parent / "memory"
 
 
 def _default_standing_orders_dir() -> Path:
@@ -230,48 +265,76 @@ def _mine_event_sequences(
     phrasings are grouped using Jaccard token similarity so that
     "Spawning too many shells" and "Spawning many shells at once" collapse
     into the same cluster.
-    """
-    raw_inputs = [
-        (p["mission_id"], text, _tokenize(text))
-        for p in patterns_data.get("patterns", [])
-        for text in (p.get("avoid", []) or [])
-        if text
-    ]
 
-    clusters: list[dict] = []
-    for mission_id, text, tokens in raw_inputs:
-        if not tokens:
+    The clusterer uses an order-independent union-find pass: every pair of
+    inputs whose Jaccard similarity meets ``similarity_threshold`` ends up in
+    the same cluster regardless of the order they were observed in.  This
+    keeps the resulting ``cluster_id`` stable across reruns and across
+    missions appended in different sequences — essential for the dismissed
+    archive to keep working.
+    """
+    raw_inputs: list[tuple[str, str, frozenset[str]]] = []
+    for p in patterns_data.get("patterns", []):
+        mission_id = p.get("mission_id")
+        if not mission_id:
             continue
-        match_idx = -1
-        best_sim = 0.0
-        for i, c in enumerate(clusters):
-            sim = _jaccard(tokens, c["tokens"])
-            if sim >= similarity_threshold and sim > best_sim:
-                best_sim = sim
-                match_idx = i
-        if match_idx == -1:
-            clusters.append({
-                "canonical": text,
-                "canonical_tokens": set(tokens),
-                "variants": {text},
-                "missions": {mission_id},
-                "tokens": set(tokens),
-            })
-        else:
-            c = clusters[match_idx]
-            c["variants"].add(text)
-            c["missions"].add(mission_id)
-            c["tokens"] |= tokens
+        for text in p.get("avoid", []) or []:
+            if not text:
+                continue
+            tokens = frozenset(_tokenize(text))
+            if not tokens:
+                continue
+            raw_inputs.append((mission_id, text, tokens))
+
+    if not raw_inputs:
+        return []
+
+    # Sort inputs deterministically so identical data always produces identical
+    # cluster assignments.
+    raw_inputs.sort(key=lambda r: (r[1], r[0]))
+
+    # Union-find over input indices, joined when Jaccard >= threshold.
+    parent = list(range(len(raw_inputs)))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(i: int, j: int) -> None:
+        ri, rj = find(i), find(j)
+        if ri != rj:
+            parent[max(ri, rj)] = min(ri, rj)
+
+    for i in range(len(raw_inputs)):
+        for j in range(i + 1, len(raw_inputs)):
+            if _jaccard(raw_inputs[i][2], raw_inputs[j][2]) >= similarity_threshold:
+                union(i, j)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(len(raw_inputs)):
+        groups.setdefault(find(i), []).append(i)
 
     out: list[RawPattern] = []
-    for c in clusters:
-        cluster_id = _canonical_fingerprint(c["canonical_tokens"])
+    for indices in groups.values():
+        members = [raw_inputs[i] for i in indices]
+        all_tokens: set[str] = set()
+        for _, _, toks in members:
+            all_tokens |= toks
+        variants = tuple(sorted({m[1] for m in members}))
+        missions = tuple(sorted({m[0] for m in members}))
+        # Canonical text is the shortest variant (ties broken alphabetically)
+        # so re-runs always pick the same representative even if the order of
+        # observation differs.
+        canonical = min(variants, key=lambda v: (len(v), v))
         out.append(RawPattern(
-            cluster_id=cluster_id,
-            canonical_text=c["canonical"],
-            variants=tuple(sorted(c["variants"])),
-            mission_ids=tuple(sorted(c["missions"])),
+            cluster_id=_canonical_fingerprint(all_tokens),
+            canonical_text=canonical,
+            variants=variants,
+            mission_ids=missions,
         ))
+    out.sort(key=lambda r: r.cluster_id)
     return out
 
 
@@ -363,8 +426,11 @@ def _score_pattern(raw: RawPattern, all_patterns: list[dict]) -> ScoredPattern:
     successes_without = 0
     failures_without = 0
     for p in all_patterns:
+        mission_id = p.get("mission_id")
+        if not mission_id:
+            continue
         achieved = bool(p.get("outcome_achieved"))
-        if p["mission_id"] in missions_with_set:
+        if mission_id in missions_with_set:
             if achieved:
                 successes_with += 1
             else:
@@ -763,6 +829,12 @@ def detect_candidate_orders(
             continue
         if sp.novelty < novelty_threshold:
             continue
+        # Polarity guard: a standing order tells captains to AVOID the pattern,
+        # so the pattern must correlate with failure (negative log-odds).
+        # A success-correlated avoid-text passing this filter would surface a
+        # candidate whose remedy is the inverse of what the data shows.
+        if sp.correlation >= 0:
+            continue
         scored.append(sp)
 
     # Pre-rank with the same heuristic the review queue uses, so synthesis
@@ -805,9 +877,16 @@ def promote_candidate(
     if candidate is None:
         raise ValueError(f"Candidate {candidate_id!r} not found in queue")
 
-    title = candidate.get("title", "").strip()
-    if not title:
+    raw_title = candidate.get("title", "").strip()
+    if not raw_title:
         raise ValueError(f"Candidate {candidate_id!r} has no title")
+    # Re-slugify at the promotion boundary: the on-disk queue is data that may
+    # have been hand-edited, so we cannot trust ``title`` to be a safe filename.
+    # Without this, a title like "../../../tmp/pwn" would escape the
+    # standing-orders directory.
+    title = _slugify(raw_title)
+    if title != raw_title:
+        candidate = {**candidate, "title": title}
 
     standing_orders_dir.mkdir(parents=True, exist_ok=True)
     out_path = standing_orders_dir / f"{title}.md"
@@ -817,8 +896,22 @@ def promote_candidate(
             "Edit the candidate title to disambiguate."
         )
 
-    out_path.write_text(_render_standing_order(candidate), encoding="utf-8")
-    _add_skill_md_row(skill_md_path, candidate)
+    # Pre-flight the SKILL.md edit before touching disk so a failed table
+    # update doesn't leave an orphan .md alongside an unchanged SKILL.md.
+    skill_md_lines = _prepare_skill_md_insertion(skill_md_path, candidate)
+
+    _write_text_atomic(out_path, _render_standing_order(candidate))
+    if skill_md_lines is not None:
+        try:
+            _write_text_atomic(skill_md_path, "\n".join(skill_md_lines))
+        except Exception:
+            # Roll back the standing-order .md so promote_candidate stays
+            # transactional from the caller's perspective.
+            try:
+                out_path.unlink()
+            except OSError:
+                pass
+            raise
 
     remaining = [c for c in candidates if c.get("id") != candidate_id]
     _save_candidates(candidates_path, remaining)
@@ -921,47 +1014,85 @@ def _render_standing_order(candidate: dict) -> str:
     )
 
 
+_SKILL_MD_SECTION_HEADING = "## Standing Orders"
 _SKILL_MD_TABLE_ROW_RE = re.compile(
     r"^\|.*`references/standing-orders/[^`]+\.md`\s*\|\s*$",
 )
 
 
-def _add_skill_md_row(skill_md_path: Path, candidate: dict) -> None:
-    """Append a new row to the Standing Orders lookup table in SKILL.md.
+def _sanitize_table_cell(text: str) -> str:
+    """Render free-text safely into a single markdown table cell.
 
-    Idempotent: skips if a row referencing the same target file already
-    exists.  If the table cannot be located the function emits a warning
-    on stderr and returns (the standing order .md still landed on disk;
-    the human reviewer can wire up the table manually).
+    Collapses any newline or carriage return into a space so that the cell
+    cannot break out of its row and inject arbitrary markdown (headings,
+    extra rows, prose) into SKILL.md.  Pipes are escaped so the cell does
+    not split into multiple columns.
+    """
+    flattened = " ".join(text.split())  # collapses all whitespace incl. \n, \r, \t
+    return flattened.replace("|", "\\|").strip()
+
+
+def _prepare_skill_md_insertion(
+    skill_md_path: Path,
+    candidate: dict,
+) -> list[str] | None:
+    """Compute the SKILL.md line list with the new row inserted.
+
+    Returns the new line list ready to be written, or ``None`` if no write is
+    needed (row already present — idempotent re-promotion).
+
+    Raises ``FileNotFoundError`` if SKILL.md is missing and ``ValueError`` if
+    the Standing Orders table cannot be located inside the expected section.
+    Pre-flighting the edit means ``promote_candidate`` does not write the
+    standing order .md until we know the table mutation will succeed.
     """
     if not skill_md_path.exists():
-        _err(f"Warning: SKILL.md not found at {skill_md_path}; skipping table update")
-        return
+        raise FileNotFoundError(
+            f"SKILL.md not found at {skill_md_path}; cannot update lookup table"
+        )
 
     text = skill_md_path.read_text(encoding="utf-8")
     title = candidate.get("title", "")
     target = f"`references/standing-orders/{title}.md`"
     if target in text:
-        return
+        return None
 
     lines = text.split("\n")
-    last_row_idx = -1
+
+    # Locate the "## Standing Orders" section so we never insert a row beneath
+    # a similar-shape table elsewhere (e.g. Damage Control).
+    section_start = -1
+    section_end = len(lines)
     for i, line in enumerate(lines):
-        if _SKILL_MD_TABLE_ROW_RE.match(line):
+        if line.strip() == _SKILL_MD_SECTION_HEADING:
+            section_start = i
+            break
+    if section_start == -1:
+        raise ValueError(
+            f"Could not locate '{_SKILL_MD_SECTION_HEADING}' heading in SKILL.md"
+        )
+    for i in range(section_start + 1, len(lines)):
+        stripped = lines[i].lstrip()
+        if stripped.startswith("## "):
+            section_end = i
+            break
+
+    last_row_idx = -1
+    for i in range(section_start, section_end):
+        if _SKILL_MD_TABLE_ROW_RE.match(lines[i]):
             last_row_idx = i
     if last_row_idx == -1:
-        _err(
-            "Warning: could not locate Standing Orders table in SKILL.md; "
-            "table row not inserted."
+        raise ValueError(
+            "Found Standing Orders heading but no lookup table rows below it"
         )
-        return
 
-    trigger = candidate.get("trigger", "").replace("|", "\\|").strip()
+    trigger = _sanitize_table_cell(candidate.get("trigger", ""))
     if not trigger:
         trigger = f"Auto-promoted candidate: {title}"
     new_row = f"| {trigger} | {target} |"
-    lines.insert(last_row_idx + 1, new_row)
-    skill_md_path.write_text("\n".join(lines), encoding="utf-8")
+    new_lines = list(lines)
+    new_lines.insert(last_row_idx + 1, new_row)
+    return new_lines
 
 
 # ---------------------------------------------------------------------------
@@ -970,9 +1101,25 @@ def _add_skill_md_row(skill_md_path: Path, candidate: dict) -> None:
 
 
 def _resolve_memory_dir(args: argparse.Namespace) -> Path:
-    """Return the memory directory from --memory-dir or the default."""
-    raw = getattr(args, "memory_dir", None)
-    return Path(raw) if raw else _default_memory_dir()
+    """Return the memory directory using the same rules as the rest of nelson-data.
+
+    Precedence:
+      1. ``--memory-dir`` if given explicitly.
+      2. ``--missions-dir`` if given — derive ``{missions_dir}/../memory`` to
+         match ``nelson_data_memory._resolve_memory_dir`` and ``cmd_brief``.
+      3. Default to ``.nelson/missions/../memory``.
+
+    Without this, ``detect-patterns`` and ``brief`` could disagree on where the
+    candidate queue lives whenever the user runs Nelson outside the default
+    ``.nelson/missions`` layout.
+    """
+    raw_memory = getattr(args, "memory_dir", None)
+    if raw_memory:
+        return Path(raw_memory)
+    raw_missions = getattr(args, "missions_dir", None)
+    if raw_missions:
+        return Path(raw_missions).parent / "memory"
+    return _default_memory_dir()
 
 
 def cmd_detect_patterns(args: argparse.Namespace) -> None:
@@ -983,11 +1130,28 @@ def cmd_detect_patterns(args: argparse.Namespace) -> None:
         if getattr(args, "standing_orders_dir", None)
         else _default_standing_orders_dir()
     )
+    json_output = bool(getattr(args, "json_output", False))
+
+    def _emit(status: str, detected: int, queue_size: int, message: str) -> None:
+        if json_output:
+            print(json.dumps({
+                "status": status,
+                "detected": detected,
+                "queue_size": queue_size,
+                "memory_dir": str(memory_dir),
+            }, indent=2))
+        else:
+            print(f"[nelson-data] {message}")
 
     if not (memory_dir / "patterns.json").exists():
-        print(
-            "[nelson-data] No patterns.json yet — nothing to detect. "
-            f"(Expected: {memory_dir / 'patterns.json'})"
+        _emit(
+            status="no-patterns",
+            detected=0,
+            queue_size=count_pending_candidates(memory_dir),
+            message=(
+                "No patterns.json yet — nothing to detect. "
+                f"(Expected: {memory_dir / 'patterns.json'})"
+            ),
         )
         return
 
@@ -1012,9 +1176,11 @@ def cmd_detect_patterns(args: argparse.Namespace) -> None:
     # Skip persistence if there's nothing on disk and nothing to add — avoids
     # littering the memory dir with empty queue files on first-runs.
     if not merged and not _candidates_path(memory_dir).exists():
-        print(
-            f"[nelson-data] Detected {len(appended)} new candidate(s); "
-            "queue is empty."
+        _emit(
+            status="ok",
+            detected=len(appended),
+            queue_size=0,
+            message=f"Detected {len(appended)} new candidate(s); queue is empty.",
         )
         return
 
@@ -1025,9 +1191,13 @@ def cmd_detect_patterns(args: argparse.Namespace) -> None:
     ]
     _save_candidates(_candidates_path(memory_dir), ranked)
 
-    print(
-        f"[nelson-data] Detected {len(appended)} new candidate(s); "
-        f"queue size: {len(ranked)}"
+    _emit(
+        status="ok",
+        detected=len(appended),
+        queue_size=len(ranked),
+        message=(
+            f"Detected {len(appended)} new candidate(s); queue size: {len(ranked)}"
+        ),
     )
 
 

--- a/skills/nelson/scripts/nelson_data_patterns.py
+++ b/skills/nelson/scripts/nelson_data_patterns.py
@@ -1,0 +1,1057 @@
+"""Darwin Gödel Machine inspired learned standing orders for Nelson.
+
+Detects candidate standing orders from accumulated mission pattern data,
+synthesizes them into Nelson-style prose, and manages the human review queue.
+
+Pipeline:
+1. Mine — cluster ``avoid`` text patterns from ``.nelson/memory/patterns.json``.
+2. Score — Fisher's exact test for correlation with mission outcomes.
+3. Filter — drop patterns similar to existing standing orders or previously
+   dismissed.
+4. Synthesize — FM-assisted prose generation (with heuristic-stub fallback).
+5. Persist — append to ``.nelson/memory/candidate-standing-orders.json`` for
+   human review.
+
+Promotion writes a new ``.md`` file under
+``skills/nelson/references/standing-orders/`` and adds a row to ``SKILL.md``.
+Dismissal moves the entry to a dismissed archive so re-runs cannot
+re-propose the same pattern.
+
+Candidates may only ADD new standing orders, never modify or remove existing
+ones — mitigates the objective-hacking failure mode documented in DGM
+Appendix H (node 114 gamed the metric by deleting hallucination-detection
+tokens).
+
+No external dependencies — stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, replace
+from hashlib import sha256
+from math import exp, lgamma, log
+from pathlib import Path
+from typing import Callable
+
+from nelson_data_utils import (
+    _die,
+    _err,
+    _file_lock,
+    _now_iso,
+    _read_json_optional,
+    _write_json,
+)
+
+
+# Type alias for FM synthesis client. Receives a prompt, returns response text
+# or ``None`` if the call could not be made (e.g. no client wired up).
+FMClient = Callable[[str], "str | None"]
+
+
+# ---------------------------------------------------------------------------
+# Tunable defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_MIN_MISSIONS = 10
+DEFAULT_CONFIDENCE_THRESHOLD = 0.7
+DEFAULT_NOVELTY_THRESHOLD = 0.3  # = 1 - max token-containment to existing orders
+DEFAULT_CLUSTER_SIMILARITY = 0.4  # Jaccard threshold for grouping avoid texts
+DEFAULT_MAX_CANDIDATES_PER_RUN = 5
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RawPattern:
+    """A clustered group of avoid texts mined from mission patterns."""
+
+    cluster_id: str
+    canonical_text: str
+    variants: tuple[str, ...]
+    mission_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ScoredPattern:
+    """A RawPattern with statistical scoring against mission outcomes."""
+
+    raw: RawPattern
+    total_missions: int
+    missions_with: int
+    missions_without: int
+    successes_with: int
+    failures_with: int
+    successes_without: int
+    failures_without: int
+    p_value: float
+    correlation: float  # log-odds ratio (positive = correlates with success)
+    confidence: float
+    frequency_score: float
+    novelty: float = 1.0
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A synthesized candidate standing order awaiting human review."""
+
+    id: str
+    title: str
+    pattern_fingerprint: str
+    trigger: str
+    anti_pattern: str
+    symptoms: tuple[str, ...]
+    remedy: str
+    related_orders: tuple[str, ...]
+    evidence_mission_ids: tuple[str, ...]
+    scores: dict
+    created_at: str
+    source: str
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Candidate":
+        return cls(
+            id=d["id"],
+            title=d.get("title", "untitled"),
+            pattern_fingerprint=d.get("pattern_fingerprint", ""),
+            trigger=d.get("trigger", ""),
+            anti_pattern=d.get("anti_pattern", ""),
+            symptoms=tuple(d.get("symptoms", [])),
+            remedy=d.get("remedy", ""),
+            related_orders=tuple(d.get("related_orders", [])),
+            evidence_mission_ids=tuple(d.get("evidence_mission_ids", [])),
+            scores=dict(d.get("scores", {})),
+            created_at=d.get("created_at", ""),
+            source=d.get("source", "unknown"),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "pattern_fingerprint": self.pattern_fingerprint,
+            "trigger": self.trigger,
+            "anti_pattern": self.anti_pattern,
+            "symptoms": list(self.symptoms),
+            "remedy": self.remedy,
+            "related_orders": list(self.related_orders),
+            "evidence_mission_ids": list(self.evidence_mission_ids),
+            "scores": dict(self.scores),
+            "created_at": self.created_at,
+            "source": self.source,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_memory_dir() -> Path:
+    return Path(".nelson/memory")
+
+
+def _default_standing_orders_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "references" / "standing-orders"
+
+
+def _default_skill_md_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "SKILL.md"
+
+
+# ---------------------------------------------------------------------------
+# Tokenisation / similarity (used for clustering and novelty)
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_STOPWORDS = frozenset({
+    "the", "and", "for", "with", "from", "into", "that", "this", "these",
+    "those", "have", "has", "had", "but", "not", "are", "was", "were",
+    "their", "there", "what", "when", "which", "while", "where", "would",
+    "could", "should", "will", "may", "can", "any", "all", "out", "too",
+    "very", "just", "also", "only", "some", "such", "than", "then", "they",
+    "you", "your", "our", "its", "his", "her",
+})
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase tokens of length >= 3, excluding common stopwords."""
+    return {
+        t for t in _TOKEN_RE.findall(text.lower())
+        if len(t) >= 3 and t not in _STOPWORDS
+    }
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def _containment(small: set[str], large: set[str]) -> float:
+    """Fraction of ``small`` covered by ``large``."""
+    if not small:
+        return 0.0
+    return len(small & large) / len(small)
+
+
+def _canonical_fingerprint(tokens: set[str]) -> str:
+    """Stable 12-hex-char hash from a canonical token set.
+
+    Sorting the tokens means re-runs that observe the same anti-pattern
+    expressed differently still resolve to the same fingerprint.
+    """
+    canonical = "|".join(sorted(tokens))
+    return sha256(canonical.encode("utf-8")).hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: Mine event sequences
+# ---------------------------------------------------------------------------
+
+
+def _mine_event_sequences(
+    patterns_data: dict,
+    *,
+    similarity_threshold: float = DEFAULT_CLUSTER_SIMILARITY,
+) -> list[RawPattern]:
+    """Cluster ``avoid`` texts across missions into recurring anti-patterns.
+
+    Each cluster represents a free-text anti-pattern recorded at stand-down
+    that has not yet been codified as a standing order. Near-duplicate
+    phrasings are grouped using Jaccard token similarity so that
+    "Spawning too many shells" and "Spawning many shells at once" collapse
+    into the same cluster.
+    """
+    raw_inputs = [
+        (p["mission_id"], text, _tokenize(text))
+        for p in patterns_data.get("patterns", [])
+        for text in (p.get("avoid", []) or [])
+        if text
+    ]
+
+    clusters: list[dict] = []
+    for mission_id, text, tokens in raw_inputs:
+        if not tokens:
+            continue
+        match_idx = -1
+        best_sim = 0.0
+        for i, c in enumerate(clusters):
+            sim = _jaccard(tokens, c["tokens"])
+            if sim >= similarity_threshold and sim > best_sim:
+                best_sim = sim
+                match_idx = i
+        if match_idx == -1:
+            clusters.append({
+                "canonical": text,
+                "canonical_tokens": set(tokens),
+                "variants": {text},
+                "missions": {mission_id},
+                "tokens": set(tokens),
+            })
+        else:
+            c = clusters[match_idx]
+            c["variants"].add(text)
+            c["missions"].add(mission_id)
+            c["tokens"] |= tokens
+
+    out: list[RawPattern] = []
+    for c in clusters:
+        cluster_id = _canonical_fingerprint(c["canonical_tokens"])
+        out.append(RawPattern(
+            cluster_id=cluster_id,
+            canonical_text=c["canonical"],
+            variants=tuple(sorted(c["variants"])),
+            mission_ids=tuple(sorted(c["missions"])),
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: Score with Fisher's exact test
+# ---------------------------------------------------------------------------
+
+
+def _log_binom(n: int, k: int) -> float:
+    if k < 0 or k > n:
+        return float("-inf")
+    return lgamma(n + 1) - lgamma(k + 1) - lgamma(n - k + 1)
+
+
+def _fisher_exact_pvalue(
+    successes_with: int,
+    failures_with: int,
+    successes_without: int,
+    failures_without: int,
+) -> float:
+    """Two-sided p-value for a 2x2 contingency table.
+
+    Table layout::
+
+                With pattern   Without pattern
+        Success      a                 b
+        Failure      c                 d
+
+    Returns 1.0 when the table is degenerate (any margin is zero), which
+    naturally pushes that pattern's confidence to 0 and filters it out.
+    """
+    a, b, c, d = successes_with, successes_without, failures_with, failures_without
+    n = a + b + c + d
+    if n == 0:
+        return 1.0
+    row1 = a + b  # successes_total
+    col1 = a + c  # missions_with_pattern_total
+    if row1 == 0 or row1 == n or col1 == 0 or col1 == n:
+        return 1.0
+
+    log_denom = _log_binom(n, col1)
+    log_p_obs = _log_binom(row1, a) + _log_binom(n - row1, c) - log_denom
+    p_obs = exp(log_p_obs)
+
+    total = 0.0
+    extreme = 0.0
+    k_min = max(0, col1 - (n - row1))
+    k_max = min(row1, col1)
+    for k in range(k_min, k_max + 1):
+        log_p = _log_binom(row1, k) + _log_binom(n - row1, col1 - k) - log_denom
+        p = exp(log_p)
+        total += p
+        if p <= p_obs * (1 + 1e-9):
+            extreme += p
+    if total <= 0:
+        return 1.0
+    return min(1.0, extreme / total)
+
+
+def _log_odds_ratio(
+    successes_with: int,
+    failures_with: int,
+    successes_without: int,
+    failures_without: int,
+) -> float:
+    """Log-odds ratio with Haldane–Anscombe continuity correction.
+
+    Positive values mean the pattern correlates with mission success;
+    negative values mean it correlates with failure.  The +0.5 correction
+    guarantees the ratio is finite and strictly positive even when any
+    cell is zero, so the surrounding ``log`` is always defined.
+    """
+    a = successes_with + 0.5
+    b = failures_with + 0.5
+    c = successes_without + 0.5
+    d = failures_without + 0.5
+    return log((a * d) / (b * c))
+
+
+def _score_pattern(raw: RawPattern, all_patterns: list[dict]) -> ScoredPattern:
+    """Score a raw pattern by correlation with mission outcomes."""
+    total = len(all_patterns)
+    missions_with_set = set(raw.mission_ids)
+    missions_with = len(missions_with_set)
+    missions_without = total - missions_with
+
+    successes_with = 0
+    failures_with = 0
+    successes_without = 0
+    failures_without = 0
+    for p in all_patterns:
+        achieved = bool(p.get("outcome_achieved"))
+        if p["mission_id"] in missions_with_set:
+            if achieved:
+                successes_with += 1
+            else:
+                failures_with += 1
+        else:
+            if achieved:
+                successes_without += 1
+            else:
+                failures_without += 1
+
+    p_value = _fisher_exact_pvalue(
+        successes_with, failures_with, successes_without, failures_without
+    )
+    correlation = _log_odds_ratio(
+        successes_with, failures_with, successes_without, failures_without
+    )
+
+    confidence = max(0.0, 1.0 - p_value)
+    frequency = missions_with / total if total > 0 else 0.0
+
+    return ScoredPattern(
+        raw=raw,
+        total_missions=total,
+        missions_with=missions_with,
+        missions_without=missions_without,
+        successes_with=successes_with,
+        failures_with=failures_with,
+        successes_without=successes_without,
+        failures_without=failures_without,
+        p_value=p_value,
+        correlation=correlation,
+        confidence=confidence,
+        frequency_score=frequency,
+    )
+
+
+def _correlate_with_outcomes(
+    raw_patterns: list[RawPattern],
+    all_patterns: list[dict],
+) -> list[ScoredPattern]:
+    """Score each raw pattern against mission outcomes."""
+    return [_score_pattern(r, all_patterns) for r in raw_patterns]
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: Novelty filter (drop patterns covered by existing orders)
+# ---------------------------------------------------------------------------
+
+
+def _load_existing_orders(
+    standing_orders_dir: Path,
+) -> list[tuple[str, str]]:
+    """Return list of (filename_stem, full_text) for each .md in the directory."""
+    if not standing_orders_dir.is_dir():
+        return []
+    out: list[tuple[str, str]] = []
+    for path in sorted(standing_orders_dir.glob("*.md")):
+        try:
+            out.append((path.stem, path.read_text(encoding="utf-8")))
+        except OSError as exc:
+            _err(f"Warning: could not read {path}: {exc}")
+    return out
+
+
+def _novelty_score(
+    raw: RawPattern,
+    existing_orders: list[tuple[str, str]],
+) -> float:
+    """Return ``1 - max(token containment)`` against any existing order.
+
+    Containment is the fraction of the pattern's tokens that appear in the
+    order document.  A pattern whose tokens are entirely covered by an
+    existing order yields novelty 0; a pattern with no token overlap yields
+    novelty 1.  Containment is more appropriate than Jaccard for comparing
+    short avoid-phrases against full standing-order documents.
+    """
+    pattern_tokens = _tokenize(raw.canonical_text)
+    for v in raw.variants:
+        pattern_tokens |= _tokenize(v)
+    if not pattern_tokens:
+        return 1.0
+
+    max_containment = 0.0
+    for name, content in existing_orders:
+        order_tokens = _tokenize(name.replace("-", " ") + " " + content)
+        c = _containment(pattern_tokens, order_tokens)
+        if c > max_containment:
+            max_containment = c
+    return 1.0 - max_containment
+
+
+# ---------------------------------------------------------------------------
+# Stage 4: Synthesise (FM call with heuristic-stub fallback)
+# ---------------------------------------------------------------------------
+
+
+SYNTHESIS_PROMPT_TEMPLATE = """You are drafting a new Nelson Standing Order from observed mission data.
+
+Style exemplar 1 (read first):
+---
+{exemplar1}
+---
+
+Style exemplar 2:
+---
+{exemplar2}
+---
+
+Detected anti-pattern (canonical phrasing): "{canonical}"
+
+Variants across missions:
+{variant_block}
+
+Evidence: this pattern appeared in {missions_with} of {total_missions} missions.
+Of those, {failures_with} failed and {successes_with} succeeded.
+Statistical confidence: {confidence:.2f} (Fisher's exact, two-sided).
+Log-odds ratio (positive = correlates with success): {correlation:.2f}.
+
+Draft a new standing order in Nelson's style. Return ONLY a JSON object with this exact schema:
+{{
+  "title": "short kebab-case identifier (e.g. echoing-decks)",
+  "trigger": "one sentence describing when this order applies",
+  "anti_pattern": "one paragraph describing the anti-pattern (Royal Navy idiom welcome)",
+  "symptoms": ["bullet describing a symptom", "another bullet", "..."],
+  "remedy": "one paragraph remedy starting with an action verb",
+  "related_orders": ["existing-order-slug", "..."]
+}}
+
+The title must be unique and not match any of the existing orders. No prose outside the JSON."""
+
+
+def _build_synthesis_prompt(
+    scored: ScoredPattern,
+    existing: list[tuple[str, str]],
+) -> str:
+    """Build the FM synthesis prompt with two compact exemplars."""
+    # Pick the two shortest standing orders as exemplars to keep prompt tight.
+    exemplars = sorted(existing, key=lambda x: len(x[1]))[:2]
+    e1 = exemplars[0][1] if exemplars else ""
+    e2 = exemplars[1][1] if len(exemplars) > 1 else ""
+    variant_lines = "\n".join(
+        f"  - \"{v}\"" for v in scored.raw.variants[:5]
+    )
+    return SYNTHESIS_PROMPT_TEMPLATE.format(
+        canonical=scored.raw.canonical_text,
+        variant_block=variant_lines,
+        missions_with=scored.missions_with,
+        total_missions=scored.total_missions,
+        failures_with=scored.failures_with,
+        successes_with=scored.successes_with,
+        confidence=scored.confidence,
+        correlation=scored.correlation,
+        exemplar1=e1,
+        exemplar2=e2,
+    )
+
+
+def _parse_fm_response(text: str) -> dict | None:
+    """Parse FM JSON output, tolerating triple-fence wrappers."""
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.splitlines()
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        cleaned = "\n".join(lines).strip()
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def _slugify(text: str) -> str:
+    """Convert free text to a safe kebab-case slug."""
+    s = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return s[:50] or "candidate-pattern"
+
+
+def _heuristic_stub(scored: ScoredPattern) -> dict:
+    """Fallback candidate fields when FM synthesis is unavailable or malformed.
+
+    The fields are deliberately conservative — the candidate carries enough
+    structure to be reviewed but flags itself as a stub via the ``source``
+    field so reviewers know to flesh it out.
+    """
+    canonical = scored.raw.canonical_text
+    slug = _slugify(canonical)
+    return {
+        "title": slug,
+        "trigger": f"Conditions resembling: {canonical}.",
+        "anti_pattern": (
+            f"Recurring pattern '{canonical}' surfaced across "
+            f"{scored.missions_with} of {scored.total_missions} missions but "
+            f"is not yet codified as a standing order."
+        ),
+        "symptoms": list(scored.raw.variants[:5]),
+        "remedy": (
+            "Investigate this pattern manually and expand the trigger, "
+            "anti-pattern, symptoms and remedy before promoting."
+        ),
+        "related_orders": [],
+    }
+
+
+def _synthesize_candidate(
+    scored: ScoredPattern,
+    existing: list[tuple[str, str]],
+    fm_client: FMClient | None,
+) -> Candidate:
+    """Run FM synthesis (or fall back to heuristic stub) and return a Candidate."""
+    data: dict | None = None
+    source = "heuristic-stub"
+
+    if fm_client is not None:
+        prompt = _build_synthesis_prompt(scored, existing)
+        try:
+            response = fm_client(prompt)
+        except Exception as exc:  # noqa: BLE001 - graceful degradation
+            _err(
+                f"FM synthesis raised {type(exc).__name__} for "
+                f"{scored.raw.cluster_id}: {exc}; using heuristic stub"
+            )
+            response = None
+        if response:
+            data = _parse_fm_response(response)
+            if data is None:
+                _err(
+                    f"FM returned malformed output for {scored.raw.cluster_id}; "
+                    "using heuristic stub"
+                )
+            else:
+                source = "fm"
+
+    if data is None:
+        data = _heuristic_stub(scored)
+
+    title = _slugify(str(data.get("title", "")) or _slugify(scored.raw.canonical_text))
+
+    return Candidate(
+        id=f"cand-{scored.raw.cluster_id}",
+        title=title,
+        pattern_fingerprint=scored.raw.cluster_id,
+        trigger=str(data.get("trigger", "")).strip(),
+        anti_pattern=str(data.get("anti_pattern", "")).strip(),
+        symptoms=tuple(str(s).strip() for s in data.get("symptoms", []) if s),
+        remedy=str(data.get("remedy", "")).strip(),
+        related_orders=tuple(
+            str(r).strip() for r in data.get("related_orders", []) if r
+        ),
+        evidence_mission_ids=tuple(scored.raw.mission_ids),
+        scores={
+            "confidence": round(scored.confidence, 4),
+            "novelty": round(scored.novelty, 4),
+            "frequency": round(scored.frequency_score, 4),
+            "correlation": round(scored.correlation, 4),
+            "missions_with": scored.missions_with,
+            "total_missions": scored.total_missions,
+        },
+        created_at=_now_iso(),
+        source=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DGM-style ranking for the review queue
+# ---------------------------------------------------------------------------
+
+
+def _review_score(confidence: float, novelty: float) -> float:
+    """DGM-style parent-selection score.
+
+    ``confidence`` is already bounded to ``[0, 1]`` (it's ``1 - p_value``),
+    so a sigmoid would only compress it into ``[0.5, 0.73]`` — too narrow
+    to discriminate.  Multiplying directly by ``(1 + novelty)`` preserves
+    the natural spread of confidence while still rewarding novel patterns
+    as an exploration bonus (range ``[1, 2]``).
+    """
+    return confidence * (1.0 + novelty)
+
+
+def rank_for_review(candidates: list[Candidate]) -> list[Candidate]:
+    """Rank candidates so the highest-value reviews surface first.
+
+    Score = confidence × (1 + novelty).  High confidence wins among
+    candidates of similar novelty; high novelty acts as a tiebreaker so
+    underexplored anti-patterns aren't buried beneath duplicates of
+    near-existing orders.
+    """
+    def _key(c: Candidate) -> float:
+        conf = float(c.scores.get("confidence", 0.0))
+        nov = float(c.scores.get("novelty", 0.0))
+        return -_review_score(conf, nov)
+
+    return sorted(candidates, key=_key)
+
+
+# ---------------------------------------------------------------------------
+# Persistence — candidate queue and dismissed archive
+# ---------------------------------------------------------------------------
+
+
+def _candidates_path(memory_dir: Path) -> Path:
+    return memory_dir / "candidate-standing-orders.json"
+
+
+def _dismissed_path(memory_dir: Path) -> Path:
+    return memory_dir / "dismissed-candidates.json"
+
+
+def _load_candidates(path: Path) -> list[dict]:
+    data = _read_json_optional(path)
+    if data is None:
+        return []
+    return list(data.get("candidates", []))
+
+
+def _save_candidates(path: Path, candidates: list[dict]) -> None:
+    lock_path = path.with_suffix(".lock")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _file_lock(lock_path):
+        _write_json(path, {
+            "version": 1,
+            "updated_at": _now_iso(),
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+        })
+
+
+def _load_dismissed(path: Path) -> list[dict]:
+    data = _read_json_optional(path)
+    if data is None:
+        return []
+    return list(data.get("dismissed", []))
+
+
+def _save_dismissed(path: Path, dismissed: list[dict]) -> None:
+    lock_path = path.with_suffix(".lock")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _file_lock(lock_path):
+        _write_json(path, {
+            "version": 1,
+            "updated_at": _now_iso(),
+            "dismissed_count": len(dismissed),
+            "dismissed": dismissed,
+        })
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def detect_candidate_orders(
+    memory_dir: Path,
+    *,
+    standing_orders_dir: Path | None = None,
+    min_missions: int = DEFAULT_MIN_MISSIONS,
+    confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+    novelty_threshold: float = DEFAULT_NOVELTY_THRESHOLD,
+    max_candidates: int = DEFAULT_MAX_CANDIDATES_PER_RUN,
+    fm_client: FMClient | None = None,
+) -> list[Candidate]:
+    """Detect candidate standing orders from accumulated mission patterns.
+
+    Pipeline: mine → score → filter (confidence + novelty + not-dismissed) →
+    rank → synthesize top-N.  Returns the newly synthesized candidates;
+    callers are responsible for merging with the existing queue and
+    persisting.
+    """
+    if standing_orders_dir is None:
+        standing_orders_dir = _default_standing_orders_dir()
+
+    patterns_data = _read_json_optional(memory_dir / "patterns.json") or {}
+    all_patterns = patterns_data.get("patterns", [])
+    if len(all_patterns) < min_missions:
+        return []
+
+    existing_orders = _load_existing_orders(standing_orders_dir)
+    dismissed = _load_dismissed(_dismissed_path(memory_dir))
+    dismissed_fingerprints = {
+        d.get("pattern_fingerprint") for d in dismissed if d.get("pattern_fingerprint")
+    }
+
+    raw_patterns = _mine_event_sequences(patterns_data)
+    if not raw_patterns:
+        return []
+
+    scored: list[ScoredPattern] = []
+    for raw in raw_patterns:
+        if raw.cluster_id in dismissed_fingerprints:
+            continue
+        sp = _score_pattern(raw, all_patterns)
+        sp = replace(sp, novelty=_novelty_score(raw, existing_orders))
+        if sp.confidence < confidence_threshold:
+            continue
+        if sp.novelty < novelty_threshold:
+            continue
+        scored.append(sp)
+
+    # Pre-rank with the same heuristic the review queue uses, so synthesis
+    # spends its FM budget on the most informative candidates first.
+    scored.sort(
+        key=lambda s: -_review_score(s.confidence, s.novelty)
+    )
+
+    return [
+        _synthesize_candidate(sp, existing_orders, fm_client)
+        for sp in scored[:max_candidates]
+    ]
+
+
+def promote_candidate(
+    candidate_id: str,
+    *,
+    memory_dir: Path,
+    standing_orders_dir: Path | None = None,
+    skill_md_path: Path | None = None,
+) -> Path:
+    """Promote a candidate to a full standing order.
+
+    Writes a new ``.md`` file under the standing-orders directory, appends a
+    row to the SKILL.md lookup table, and removes the candidate from the
+    pending queue.  Returns the path of the newly written file.
+
+    Raises ``ValueError`` if the candidate is not found.  Raises
+    ``FileExistsError`` if a standing order with the same title already
+    exists (refuses to overwrite hand-written orders).
+    """
+    if standing_orders_dir is None:
+        standing_orders_dir = _default_standing_orders_dir()
+    if skill_md_path is None:
+        skill_md_path = _default_skill_md_path()
+
+    candidates_path = _candidates_path(memory_dir)
+    candidates = _load_candidates(candidates_path)
+    candidate = next((c for c in candidates if c.get("id") == candidate_id), None)
+    if candidate is None:
+        raise ValueError(f"Candidate {candidate_id!r} not found in queue")
+
+    title = candidate.get("title", "").strip()
+    if not title:
+        raise ValueError(f"Candidate {candidate_id!r} has no title")
+
+    standing_orders_dir.mkdir(parents=True, exist_ok=True)
+    out_path = standing_orders_dir / f"{title}.md"
+    if out_path.exists():
+        raise FileExistsError(
+            f"Standing order already exists at {out_path}; will not overwrite. "
+            "Edit the candidate title to disambiguate."
+        )
+
+    out_path.write_text(_render_standing_order(candidate), encoding="utf-8")
+    _add_skill_md_row(skill_md_path, candidate)
+
+    remaining = [c for c in candidates if c.get("id") != candidate_id]
+    _save_candidates(candidates_path, remaining)
+    return out_path
+
+
+def dismiss_candidate(
+    candidate_id: str,
+    *,
+    memory_dir: Path,
+    reason: str,
+) -> None:
+    """Move a candidate from the pending queue to the dismissed archive.
+
+    Subsequent ``detect_candidate_orders`` runs will not re-propose
+    patterns with the same fingerprint — avoiding reviewer fatigue.
+    """
+    candidates_path = _candidates_path(memory_dir)
+    dismissed_path = _dismissed_path(memory_dir)
+
+    candidates = _load_candidates(candidates_path)
+    candidate = next((c for c in candidates if c.get("id") == candidate_id), None)
+    if candidate is None:
+        raise ValueError(f"Candidate {candidate_id!r} not found in queue")
+
+    dismissed = _load_dismissed(dismissed_path)
+    dismissed.append({
+        "id": candidate_id,
+        "reason": reason,
+        "dismissed_at": _now_iso(),
+        "pattern_fingerprint": candidate.get("pattern_fingerprint", ""),
+        "title": candidate.get("title", ""),
+    })
+    _save_dismissed(dismissed_path, dismissed)
+
+    remaining = [c for c in candidates if c.get("id") != candidate_id]
+    _save_candidates(candidates_path, remaining)
+
+
+def count_pending_candidates(memory_dir: Path) -> int:
+    """Return the number of candidates awaiting review."""
+    return len(_load_candidates(_candidates_path(memory_dir)))
+
+
+# ---------------------------------------------------------------------------
+# Standing order rendering and SKILL.md update
+# ---------------------------------------------------------------------------
+
+
+_STANDING_ORDER_TEMPLATE = """# Standing Order: {title_human}
+
+{anti_pattern}
+
+**Trigger:** {trigger}
+
+**Symptoms:**
+{symptoms_block}
+
+**Remedy:** {remedy}
+{related_block}
+<!-- audit-lineage: promoted from candidate {candidate_id}; evidence missions: {evidence} -->
+"""
+
+
+def _human_title(slug: str) -> str:
+    return " ".join(w.capitalize() for w in slug.split("-") if w)
+
+
+def _render_standing_order(candidate: dict) -> str:
+    """Render a candidate dict as a standing-order .md document."""
+    symptoms = candidate.get("symptoms") or []
+    if symptoms:
+        symptoms_block = "\n".join(f"- {s}" for s in symptoms)
+    else:
+        symptoms_block = "- (to be expanded by human reviewer before merge)"
+
+    related = candidate.get("related_orders") or []
+    if related:
+        related_block = (
+            "\n**Related orders:** "
+            + ", ".join(f"`{r}.md`" for r in related)
+            + "\n"
+        )
+    else:
+        related_block = ""
+
+    evidence_list = candidate.get("evidence_mission_ids") or []
+    evidence = ", ".join(evidence_list) if evidence_list else "(none recorded)"
+
+    return _STANDING_ORDER_TEMPLATE.format(
+        title_human=_human_title(candidate.get("title", "Untitled")),
+        anti_pattern=candidate.get("anti_pattern", "").strip()
+            or "(no anti-pattern description supplied — expand before merge)",
+        trigger=candidate.get("trigger", "").strip() or "(supply trigger)",
+        symptoms_block=symptoms_block,
+        remedy=candidate.get("remedy", "").strip() or "(supply remedy)",
+        related_block=related_block,
+        candidate_id=candidate.get("id", "unknown"),
+        evidence=evidence,
+    )
+
+
+_SKILL_MD_TABLE_ROW_RE = re.compile(
+    r"^\|.*`references/standing-orders/[^`]+\.md`\s*\|\s*$",
+)
+
+
+def _add_skill_md_row(skill_md_path: Path, candidate: dict) -> None:
+    """Append a new row to the Standing Orders lookup table in SKILL.md.
+
+    Idempotent: skips if a row referencing the same target file already
+    exists.  If the table cannot be located the function emits a warning
+    on stderr and returns (the standing order .md still landed on disk;
+    the human reviewer can wire up the table manually).
+    """
+    if not skill_md_path.exists():
+        _err(f"Warning: SKILL.md not found at {skill_md_path}; skipping table update")
+        return
+
+    text = skill_md_path.read_text(encoding="utf-8")
+    title = candidate.get("title", "")
+    target = f"`references/standing-orders/{title}.md`"
+    if target in text:
+        return
+
+    lines = text.split("\n")
+    last_row_idx = -1
+    for i, line in enumerate(lines):
+        if _SKILL_MD_TABLE_ROW_RE.match(line):
+            last_row_idx = i
+    if last_row_idx == -1:
+        _err(
+            "Warning: could not locate Standing Orders table in SKILL.md; "
+            "table row not inserted."
+        )
+        return
+
+    trigger = candidate.get("trigger", "").replace("|", "\\|").strip()
+    if not trigger:
+        trigger = f"Auto-promoted candidate: {title}"
+    new_row = f"| {trigger} | {target} |"
+    lines.insert(last_row_idx + 1, new_row)
+    skill_md_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI handlers — wired into nelson-data.py
+# ---------------------------------------------------------------------------
+
+
+def _resolve_memory_dir(args: argparse.Namespace) -> Path:
+    """Return the memory directory from --memory-dir or the default."""
+    raw = getattr(args, "memory_dir", None)
+    return Path(raw) if raw else _default_memory_dir()
+
+
+def cmd_detect_patterns(args: argparse.Namespace) -> None:
+    """CLI: detect candidate standing orders and append them to the queue."""
+    memory_dir = _resolve_memory_dir(args)
+    standing_orders_dir = (
+        Path(args.standing_orders_dir)
+        if getattr(args, "standing_orders_dir", None)
+        else _default_standing_orders_dir()
+    )
+
+    if not (memory_dir / "patterns.json").exists():
+        print(
+            "[nelson-data] No patterns.json yet — nothing to detect. "
+            f"(Expected: {memory_dir / 'patterns.json'})"
+        )
+        return
+
+    new_candidates = detect_candidate_orders(
+        memory_dir,
+        standing_orders_dir=standing_orders_dir,
+        min_missions=args.min_missions,
+        confidence_threshold=args.confidence_threshold,
+        fm_client=None,
+    )
+
+    existing_dicts = _load_candidates(_candidates_path(memory_dir))
+    existing_fps = {c.get("pattern_fingerprint") for c in existing_dicts}
+
+    appended: list[dict] = []
+    for cand in new_candidates:
+        if cand.pattern_fingerprint in existing_fps:
+            continue
+        appended.append(cand.to_dict())
+
+    merged = existing_dicts + appended
+    # Skip persistence if there's nothing on disk and nothing to add — avoids
+    # littering the memory dir with empty queue files on first-runs.
+    if not merged and not _candidates_path(memory_dir).exists():
+        print(
+            f"[nelson-data] Detected {len(appended)} new candidate(s); "
+            "queue is empty."
+        )
+        return
+
+    # Re-rank the whole queue so the highest-priority items surface first.
+    ranked = [
+        c.to_dict()
+        for c in rank_for_review([Candidate.from_dict(c) for c in merged])
+    ]
+    _save_candidates(_candidates_path(memory_dir), ranked)
+
+    print(
+        f"[nelson-data] Detected {len(appended)} new candidate(s); "
+        f"queue size: {len(ranked)}"
+    )
+
+
+def cmd_promote_candidate(args: argparse.Namespace) -> None:
+    """CLI: promote a candidate to a real standing order."""
+    memory_dir = _resolve_memory_dir(args)
+    try:
+        out_path = promote_candidate(args.candidate_id, memory_dir=memory_dir)
+    except (ValueError, FileExistsError) as exc:
+        _die(f"Error: {exc}")
+        return
+    print(f"[nelson-data] Promoted {args.candidate_id} -> {out_path}")
+
+
+def cmd_dismiss_candidate(args: argparse.Namespace) -> None:
+    """CLI: dismiss a candidate with a reason."""
+    memory_dir = _resolve_memory_dir(args)
+    try:
+        dismiss_candidate(
+            args.candidate_id,
+            memory_dir=memory_dir,
+            reason=args.reason,
+        )
+    except ValueError as exc:
+        _die(f"Error: {exc}")
+        return
+    print(f"[nelson-data] Dismissed {args.candidate_id}: {args.reason}")

--- a/skills/nelson/scripts/test_nelson_data_patterns.py
+++ b/skills/nelson/scripts/test_nelson_data_patterns.py
@@ -27,6 +27,8 @@ from nelson_data_patterns import (
     _mine_event_sequences,
     _novelty_score,
     _parse_fm_response,
+    _prepare_skill_md_insertion,
+    _sanitize_table_cell,
     _score_pattern,
     count_pending_candidates,
     detect_candidate_orders,
@@ -583,6 +585,7 @@ class TestPromotion:
         so_dir = _empty_standing_orders_dir(tmp_path)
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text(
+            "## Standing Orders\n\n"
             "| Situation | Standing Order |\n|---|---|\n"
             "| Existing | `references/standing-orders/split-keel.md` |\n",
             encoding="utf-8",
@@ -603,6 +606,7 @@ class TestPromotion:
         so_dir = _empty_standing_orders_dir(tmp_path)
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text(
+            "## Standing Orders\n\n"
             "| Situation | Standing Order |\n|---|---|\n"
             "| Existing | `references/standing-orders/split-keel.md` |\n",
             encoding="utf-8",
@@ -719,7 +723,8 @@ class TestCLI:
         cid = queue["candidates"][0]["id"]
 
         run(
-            "dismiss-candidate", cid,
+            "dismiss-candidate",
+            "--candidate-id", cid,
             "--reason", "duplicate of split-keel",
             "--memory-dir", str(memory_dir),
             cwd=tmp_path,
@@ -737,7 +742,8 @@ class TestCLI:
         memory_dir = tmp_path / ".nelson" / "memory"
         memory_dir.mkdir(parents=True)
         run(
-            "promote-candidate", "cand-missing",
+            "promote-candidate",
+            "--candidate-id", "cand-missing",
             "--memory-dir", str(memory_dir),
             cwd=tmp_path,
             expect_fail=True,
@@ -775,3 +781,401 @@ class TestBriefSurfacing:
 
         result = run("brief", "--missions-dir", str(tmp_path / ".nelson" / "missions"), cwd=tmp_path)
         assert "CANDIDATE STANDING ORDERS (awaiting review): 1" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Regressions surfaced by PR review (#120)
+# ---------------------------------------------------------------------------
+
+
+class TestClusterStability:
+    """Cluster fingerprint must be invariant under input order.
+
+    Documented contract at module line 211: "re-runs that observe the same
+    anti-pattern expressed differently still resolve to the same fingerprint."
+    """
+
+    def _data(self, ordering: list[str]) -> dict:
+        # Three avoid texts where the middle one bridges the other two — under
+        # the old greedy clusterer, this collapsed to one cluster or two
+        # depending on the order observed.
+        bank = {
+            "a": "shells coordination parallel spawn",
+            "b": "shells coordination",
+            "c": "parallel spawn workflow",
+        }
+        return {
+            "patterns": [
+                {"mission_id": f"m-{k}", "avoid": [bank[k]]} for k in ordering
+            ]
+        }
+
+    def test_cluster_id_invariant_under_reordering(self) -> None:
+        order1 = _mine_event_sequences(self._data(["a", "b", "c"]))
+        order2 = _mine_event_sequences(self._data(["c", "b", "a"]))
+        order3 = _mine_event_sequences(self._data(["b", "a", "c"]))
+        ids1 = sorted(c.cluster_id for c in order1)
+        ids2 = sorted(c.cluster_id for c in order2)
+        ids3 = sorted(c.cluster_id for c in order3)
+        assert ids1 == ids2 == ids3, (
+            f"Cluster IDs diverged under reordering: {ids1} vs {ids2} vs {ids3}"
+        )
+
+    def test_bridge_pattern_groups_consistently(self) -> None:
+        # The bridge text "b" must connect "a" and "c" regardless of order.
+        order1 = _mine_event_sequences(self._data(["a", "b", "c"]))
+        order2 = _mine_event_sequences(self._data(["c", "b", "a"]))
+        assert len(order1) == len(order2)
+
+
+class TestPolarityGate:
+    """Standing orders are 'avoid this' — the candidate gate must require
+    that the pattern correlate with failure (negative log-odds)."""
+
+    def test_success_correlated_avoid_text_is_filtered_out(
+        self, tmp_path: Path
+    ) -> None:
+        # Build a synthetic dataset where the avoid-text only appears in
+        # SUCCESSFUL missions.  Old impl: confidence 0.998 → candidate surfaces.
+        # New impl: correlation > 0 → filtered out at the gate.
+        memory_dir = tmp_path / "memory"
+        patterns: list[dict] = []
+        for i in range(8):
+            patterns.append({
+                "mission_id": f"win-{i}",
+                "outcome_achieved": True,
+                "avoid": ["wardroom timetable was burned"],
+                "adopt": [],
+                "standing_order_violations": [],
+                "damage_control_events": 0,
+            })
+        for i in range(4):
+            patterns.append({
+                "mission_id": f"loss-{i}",
+                "outcome_achieved": False,
+                "avoid": [],
+                "adopt": [],
+                "standing_order_violations": [],
+                "damage_control_events": 0,
+            })
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "patterns.json").write_text(
+            json.dumps({"version": 1, "pattern_count": len(patterns), "patterns": patterns}),
+            encoding="utf-8",
+        )
+
+        candidates = detect_candidate_orders(
+            memory_dir,
+            standing_orders_dir=_empty_standing_orders_dir(tmp_path),
+            min_missions=10,
+        )
+        assert candidates == [], (
+            "Success-correlated avoid texts must not surface as anti-pattern "
+            "candidates; remedy would invert the data."
+        )
+
+
+class TestPathTraversalGuard:
+    def test_promote_rejects_title_with_path_traversal(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "## Standing Orders\n\n"
+            "| Situation | Standing Order |\n|---|---|\n"
+            "| Existing | `references/standing-orders/split-keel.md` |\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate(title="../../../tmp/pwn", id="cand-evil")
+        _seed_candidate(memory_dir, cand)
+
+        out_path = promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        # The slug rewrite forces the new file under so_dir, not /tmp.
+        assert out_path.parent == so_dir
+        assert ".." not in out_path.name
+        assert "/" not in out_path.name
+        # And nothing escaped the standing-orders directory.
+        outside_files = list(tmp_path.glob("**/pwn.md"))
+        assert outside_files == [out_path] or outside_files == []
+
+
+class TestSkillMdInjectionGuard:
+    def test_newline_in_trigger_is_neutralised(self) -> None:
+        evil = "step one\n## OVERRIDE\n| evil | row |"
+        cleaned = _sanitize_table_cell(evil)
+        assert "\n" not in cleaned
+        assert "##" in cleaned  # text is preserved as a single line
+        # And pipe escaping survives the flatten
+        assert "\\|" in cleaned
+
+    def test_promote_inserts_into_standing_orders_section_only(
+        self, tmp_path: Path
+    ) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        # Damage Control table appears BEFORE Standing Orders.  Old impl would
+        # take the last table-shape line in the entire file as anchor; new impl
+        # must insert beneath Standing Orders specifically.
+        skill_md.write_text(
+            "## Damage Control\n\n"
+            "| Situation | Procedure |\n|---|---|\n"
+            "| Other | `references/standing-orders/decoy.md` |\n\n"
+            "## Standing Orders\n\n"
+            "| Situation | Standing Order |\n|---|---|\n"
+            "| Existing | `references/standing-orders/split-keel.md` |\n\n"
+            "## Trailing section\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+        promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        text = skill_md.read_text(encoding="utf-8")
+        # New row appears below the Standing Orders heading, above Trailing
+        so_idx = text.index("## Standing Orders")
+        trailing_idx = text.index("## Trailing section")
+        new_row_idx = text.index("echoing-decks.md")
+        assert so_idx < new_row_idx < trailing_idx
+
+
+class TestPromoteIdempotency:
+    def test_promote_then_promote_again_is_clean(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "## Standing Orders\n\n"
+            "| Situation | Standing Order |\n|---|---|\n"
+            "| Existing | `references/standing-orders/split-keel.md` |\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+        promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        # Same row shouldn't appear twice if pre-insertion is called twice.
+        text_after_first = skill_md.read_text(encoding="utf-8")
+        # Manually re-run the SKILL.md preparation for the same candidate to
+        # confirm idempotency on the table mutation path.
+        result = _prepare_skill_md_insertion(skill_md, cand.to_dict())
+        assert result is None  # already present → no-op
+        assert text_after_first.count("`references/standing-orders/echoing-decks.md`") == 1
+
+    def test_promote_missing_skill_md_raises_before_writing_md(
+        self, tmp_path: Path
+    ) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+        # No SKILL.md on disk → must fail before writing the standing order .md
+        try:
+            promote_candidate(
+                cand.id,
+                memory_dir=memory_dir,
+                standing_orders_dir=so_dir,
+                skill_md_path=tmp_path / "SKILL.md",
+            )
+        except FileNotFoundError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("Expected FileNotFoundError")
+        assert not (so_dir / "echoing-decks.md").exists()
+
+    def test_promote_table_missing_aborts_atomically(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        # Heading present but no table beneath it.
+        skill_md.write_text(
+            "# Skill\n\n## Standing Orders\n\nNo table here.\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+        try:
+            promote_candidate(
+                cand.id,
+                memory_dir=memory_dir,
+                standing_orders_dir=so_dir,
+                skill_md_path=skill_md,
+            )
+        except ValueError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("Expected ValueError when table missing")
+        # Neither file should have been mutated.
+        assert not (so_dir / "echoing-decks.md").exists()
+        assert "echoing-decks" not in skill_md.read_text(encoding="utf-8")
+        # Candidate still in queue — no partial commit.
+        assert count_pending_candidates(memory_dir) == 1
+
+
+class TestAddOnlyInvariant:
+    """The headline DGM safety claim: candidates may ADD standing orders but
+    never modify or delete existing ones (DGM Appendix H mitigation)."""
+
+    def test_existing_standing_orders_files_are_untouched_after_promote(
+        self, tmp_path: Path
+    ) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        existing_path = so_dir / "split-keel.md"
+        existing_content = "# Split Keel\n\nHand-written, must not change.\n"
+        existing_path.write_text(existing_content, encoding="utf-8")
+        another_path = so_dir / "becalmed-fleet.md"
+        another_content = "# Becalmed Fleet\n\nAlso hand-written.\n"
+        another_path.write_text(another_content, encoding="utf-8")
+
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "## Standing Orders\n\n"
+            "| Situation | Standing Order |\n|---|---|\n"
+            "| Split keel | `references/standing-orders/split-keel.md` |\n"
+            "| Becalmed | `references/standing-orders/becalmed-fleet.md` |\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+
+        promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        # Existing files are byte-identical
+        assert existing_path.read_text(encoding="utf-8") == existing_content
+        assert another_path.read_text(encoding="utf-8") == another_content
+        # New file is the only addition
+        new_files = sorted(p.name for p in so_dir.glob("*.md"))
+        assert new_files == ["becalmed-fleet.md", "echoing-decks.md", "split-keel.md"]
+
+    def test_existing_skill_md_rows_are_preserved(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        original = (
+            "## Standing Orders\n\n"
+            "| Situation | Standing Order |\n|---|---|\n"
+            "| Split keel | `references/standing-orders/split-keel.md` |\n"
+            "| Becalmed | `references/standing-orders/becalmed-fleet.md` |\n"
+        )
+        skill_md.write_text(original, encoding="utf-8")
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+        promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        updated = skill_md.read_text(encoding="utf-8")
+        # Every original row still present, byte for byte.
+        for line in original.split("\n"):
+            assert line in updated
+
+
+class TestEmptyQueueSkipsWrite:
+    def test_detect_patterns_does_not_create_empty_queue_on_first_run(
+        self, tmp_path: Path
+    ) -> None:
+        memory_dir = tmp_path / ".nelson" / "memory"
+        # patterns.json exists but has no failure correlation → 0 candidates.
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=0, without_pattern_succeeding=12
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        run(
+            "detect-patterns",
+            "--memory-dir", str(memory_dir),
+            "--standing-orders-dir", str(so_dir),
+            "--min-missions", "10",
+            cwd=tmp_path,
+        )
+        queue_path = memory_dir / "candidate-standing-orders.json"
+        assert not queue_path.exists(), (
+            "First-run with no candidates must not litter the memory dir."
+        )
+
+
+class TestMissionDirDerivation:
+    """detect-patterns and brief must read the same memory dir when given the
+    same --missions-dir, even when it is not the default location."""
+
+    def test_detect_patterns_with_missions_dir_finds_queue_seen_by_brief(
+        self, tmp_path: Path
+    ) -> None:
+        # Non-default layout: project_root/.nelson/missions and memory siblings
+        missions_dir = tmp_path / "project" / ".nelson" / "missions"
+        missions_dir.mkdir(parents=True)
+        memory_dir = missions_dir.parent / "memory"  # The derived path
+        memory_dir.mkdir()
+
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        # Run from a CWD that is NOT the project root — old impl would use
+        # cwd-relative .nelson/memory and miss the queue entirely.
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        result = run(
+            "detect-patterns",
+            "--missions-dir", str(missions_dir),
+            "--standing-orders-dir", str(so_dir),
+            "--min-missions", "10",
+            cwd=elsewhere,
+        )
+        assert "Detected 1 new candidate" in result.stdout
+        # Queue must land where brief will look for it.
+        assert (memory_dir / "candidate-standing-orders.json").exists()
+
+
+class TestMalformedRecordTolerance:
+    def test_missing_mission_id_is_skipped_not_raised(self) -> None:
+        # Old impl: KeyError on the first record without "mission_id".
+        data = {
+            "patterns": [
+                {"avoid": ["something"], "outcome_achieved": False},  # no id
+                {"mission_id": "m1", "avoid": ["other"], "outcome_achieved": True},
+            ]
+        }
+        clusters = _mine_event_sequences(data)
+        # The bad record was skipped silently; the good one survives.
+        assert any("other" in c.canonical_text for c in clusters)
+
+
+class TestDetectPatternsJsonOutput:
+    def test_json_flag_emits_machine_readable_summary(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / ".nelson" / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        result = run(
+            "detect-patterns",
+            "--memory-dir", str(memory_dir),
+            "--standing-orders-dir", str(so_dir),
+            "--min-missions", "10",
+            "--json",
+            cwd=tmp_path,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        assert payload["detected"] == 1
+        assert payload["queue_size"] == 1

--- a/skills/nelson/scripts/test_nelson_data_patterns.py
+++ b/skills/nelson/scripts/test_nelson_data_patterns.py
@@ -1,0 +1,777 @@
+"""Tests for the DGM-inspired learned standing orders pipeline.
+
+Covers:
+- Synthetic-data detection: planted anti-pattern surfaces with high confidence.
+- Edge cases: empty / single-mission / all-success / all-failure data sets.
+- Novelty filter: patterns covered by existing orders are dropped.
+- Dismissed archive: re-running detection does not re-surface a dismissed pattern.
+- Promotion: writes a well-formed .md and updates the SKILL.md lookup table.
+- rank_for_review ordering: confidence × novelty (DGM parent-selection style).
+- CLI smoke: detect-patterns reports gracefully on empty memory; promote /
+  dismiss handlers fail with a clear error when the candidate is unknown.
+- Brief surfacing: the candidate count appears when present and is omitted
+  cleanly when zero.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import read_json, run
+
+from nelson_data_patterns import (
+    Candidate,
+    _fisher_exact_pvalue,
+    _heuristic_stub,
+    _mine_event_sequences,
+    _novelty_score,
+    _parse_fm_response,
+    _score_pattern,
+    count_pending_candidates,
+    detect_candidate_orders,
+    dismiss_candidate,
+    promote_candidate,
+    rank_for_review,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+PLANTED = "Spawning too many shells without coordination plan"
+
+
+def _make_patterns_file(
+    memory_dir: Path,
+    *,
+    with_pattern_failing: int,
+    without_pattern_succeeding: int,
+    extra_noise_avoid: list[str] | None = None,
+) -> None:
+    """Write a synthetic patterns.json into *memory_dir*.
+
+    The planted pattern PLANTED appears in `with_pattern_failing` missions,
+    all of which failed.  Another `without_pattern_succeeding` missions
+    succeeded without the pattern.  Together they form a strong negative
+    correlation that Fisher's exact will detect with high confidence.
+    """
+    patterns = []
+    counter = 0
+    for _ in range(with_pattern_failing):
+        counter += 1
+        patterns.append({
+            "mission_id": f"2026-01-01_{counter:06d}",
+            "outcome_achieved": False,
+            "adopt": [],
+            "avoid": [PLANTED, *(extra_noise_avoid or [])],
+            "standing_order_violations": [],
+            "damage_control_events": 0,
+        })
+    for _ in range(without_pattern_succeeding):
+        counter += 1
+        patterns.append({
+            "mission_id": f"2026-01-01_{counter:06d}",
+            "outcome_achieved": True,
+            "adopt": ["Clean dispatch"],
+            "avoid": [],
+            "standing_order_violations": [],
+            "damage_control_events": 0,
+        })
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    (memory_dir / "patterns.json").write_text(
+        json.dumps({
+            "version": 1,
+            "updated_at": "2026-01-02T00:00:00Z",
+            "pattern_count": len(patterns),
+            "patterns": patterns,
+        }),
+        encoding="utf-8",
+    )
+
+
+def _empty_standing_orders_dir(tmp_path: Path) -> Path:
+    so_dir = tmp_path / "standing-orders"
+    so_dir.mkdir()
+    return so_dir
+
+
+# ---------------------------------------------------------------------------
+# Statistical primitives
+# ---------------------------------------------------------------------------
+
+
+class TestFisherExact:
+    def test_strong_signal_low_pvalue(self) -> None:
+        # 4 failures all have the pattern; 8 successes never do
+        p = _fisher_exact_pvalue(0, 8, 4, 0)
+        assert p < 0.01
+
+    def test_no_signal_high_pvalue(self) -> None:
+        # Pattern equally distributed across successes and failures
+        p = _fisher_exact_pvalue(4, 4, 4, 4)
+        assert p > 0.5
+
+    def test_degenerate_table_returns_one(self) -> None:
+        assert _fisher_exact_pvalue(0, 0, 0, 0) == 1.0
+        assert _fisher_exact_pvalue(0, 0, 5, 5) == 1.0  # all in one row
+
+
+# ---------------------------------------------------------------------------
+# Mining (clustering) and scoring
+# ---------------------------------------------------------------------------
+
+
+class TestMining:
+    def test_groups_near_duplicates(self) -> None:
+        data = {
+            "patterns": [
+                {"mission_id": "m1", "avoid": ["Spawning many shells at once"]},
+                {"mission_id": "m2", "avoid": ["Spawning too many shells without plan"]},
+                {"mission_id": "m3", "avoid": ["Forgot to ration tokens"]},
+            ]
+        }
+        clusters = _mine_event_sequences(data, similarity_threshold=0.3)
+        # The two "shell" phrases should cluster; the token-ration phrase stands alone
+        shell_clusters = [
+            c for c in clusters if "shells" in c.canonical_text.lower()
+        ]
+        assert len(shell_clusters) == 1
+        assert len(shell_clusters[0].mission_ids) == 2
+
+    def test_empty_input_yields_no_clusters(self) -> None:
+        assert _mine_event_sequences({}) == []
+        assert _mine_event_sequences({"patterns": []}) == []
+
+    def test_blank_avoid_text_skipped(self) -> None:
+        data = {"patterns": [{"mission_id": "m1", "avoid": ["", "   "]}]}
+        assert _mine_event_sequences(data) == []
+
+
+class TestScoring:
+    def test_correlated_pattern_high_confidence(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        patterns_data = json.loads(
+            (memory_dir / "patterns.json").read_text(encoding="utf-8")
+        )
+        clusters = _mine_event_sequences(patterns_data)
+        assert len(clusters) == 1, f"Expected one cluster, got {len(clusters)}"
+        scored = _score_pattern(clusters[0], patterns_data["patterns"])
+        assert scored.missions_with == 4
+        assert scored.failures_with == 4
+        assert scored.successes_with == 0
+        assert scored.confidence > 0.95, (
+            f"Expected high confidence, got {scored.confidence}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Novelty
+# ---------------------------------------------------------------------------
+
+
+class TestNovelty:
+    def test_pattern_covered_by_existing_order_is_low_novelty(
+        self, tmp_path: Path
+    ) -> None:
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        (so_dir / "split-keel.md").write_text(
+            "# Standing Order: Split Keel\n\n"
+            "Do not assign the same file to multiple captains.\n\n"
+            "**Symptoms:** captains overwrite each other; merge conflicts on the "
+            "same artifact; coordination time reconciling divergent edits.\n",
+            encoding="utf-8",
+        )
+        data = {
+            "patterns": [
+                {
+                    "mission_id": "m1",
+                    "avoid": ["captains overwrite same artifact merge conflicts"],
+                }
+            ]
+        }
+        clusters = _mine_event_sequences(data)
+        existing = [(p.stem, p.read_text(encoding="utf-8")) for p in so_dir.glob("*.md")]
+        novelty = _novelty_score(clusters[0], existing)
+        assert novelty < 0.3, f"Expected low novelty for known pattern, got {novelty}"
+
+    def test_unrelated_pattern_is_high_novelty(self, tmp_path: Path) -> None:
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        (so_dir / "split-keel.md").write_text(
+            "# Split Keel — file ownership\n", encoding="utf-8"
+        )
+        data = {"patterns": [{"mission_id": "m1", "avoid": [PLANTED]}]}
+        clusters = _mine_event_sequences(data)
+        existing = [(p.stem, p.read_text(encoding="utf-8")) for p in so_dir.glob("*.md")]
+        novelty = _novelty_score(clusters[0], existing)
+        assert novelty > 0.5
+
+
+# ---------------------------------------------------------------------------
+# End-to-end detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCandidateOrders:
+    def test_planted_pattern_is_detected(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        candidates = detect_candidate_orders(
+            memory_dir,
+            standing_orders_dir=so_dir,
+            min_missions=10,
+            confidence_threshold=0.7,
+        )
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand.scores["confidence"] > 0.7
+        assert cand.evidence_mission_ids  # mission lineage carried through
+
+    def test_below_min_missions_returns_nothing(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=2, without_pattern_succeeding=3
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        assert detect_candidate_orders(
+            memory_dir, standing_orders_dir=so_dir, min_missions=10
+        ) == []
+
+    def test_empty_memory_returns_nothing(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        (memory_dir / "patterns.json").write_text('{"patterns": []}', encoding="utf-8")
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        assert detect_candidate_orders(
+            memory_dir, standing_orders_dir=so_dir, min_missions=0
+        ) == []
+
+    def test_all_success_returns_nothing(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=0, without_pattern_succeeding=12
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        # No failures at all → no anti-pattern is correlated with failure
+        assert detect_candidate_orders(
+            memory_dir, standing_orders_dir=so_dir, min_missions=10
+        ) == []
+
+    def test_pattern_matching_existing_order_dropped(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        # Plant a pattern whose tokens are fully covered by the existing order
+        (so_dir / "split-keel.md").write_text(
+            "# Split Keel\nfile captain assignment overwrite merge conflict ownership\n",
+            encoding="utf-8",
+        )
+
+        patterns = []
+        for i in range(4):
+            patterns.append({
+                "mission_id": f"m{i}",
+                "outcome_achieved": False,
+                "avoid": ["file captain assignment overwrite ownership"],
+                "adopt": [],
+                "standing_order_violations": [],
+                "damage_control_events": 0,
+            })
+        for i in range(8):
+            patterns.append({
+                "mission_id": f"n{i}",
+                "outcome_achieved": True,
+                "avoid": [],
+                "adopt": [],
+                "standing_order_violations": [],
+                "damage_control_events": 0,
+            })
+        memory_dir.mkdir(parents=True, exist_ok=True)
+        (memory_dir / "patterns.json").write_text(
+            json.dumps({"version": 1, "pattern_count": 12, "patterns": patterns}),
+            encoding="utf-8",
+        )
+
+        candidates = detect_candidate_orders(
+            memory_dir,
+            standing_orders_dir=so_dir,
+            min_missions=10,
+        )
+        assert candidates == [], (
+            "Existing-order coverage should suppress the candidate"
+        )
+
+    def test_dismissed_pattern_not_resurfaced(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        first = detect_candidate_orders(
+            memory_dir, standing_orders_dir=so_dir, min_missions=10
+        )
+        assert len(first) == 1
+        cand = first[0]
+
+        # Persist the candidate so dismiss_candidate can find it
+        queue_path = memory_dir / "candidate-standing-orders.json"
+        queue_path.write_text(
+            json.dumps({
+                "version": 1,
+                "updated_at": "2026-01-02T00:00:00Z",
+                "candidate_count": 1,
+                "candidates": [cand.to_dict()],
+            }),
+            encoding="utf-8",
+        )
+
+        dismiss_candidate(cand.id, memory_dir=memory_dir, reason="duplicate")
+        assert detect_candidate_orders(
+            memory_dir, standing_orders_dir=so_dir, min_missions=10
+        ) == []
+
+
+# ---------------------------------------------------------------------------
+# Synthesis (with and without an FM client)
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesis:
+    def test_heuristic_stub_used_when_no_fm(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        candidates = detect_candidate_orders(
+            memory_dir, standing_orders_dir=so_dir, min_missions=10, fm_client=None
+        )
+        assert candidates[0].source == "heuristic-stub"
+        assert candidates[0].title  # slug derived from canonical text
+
+    def test_fm_client_supplies_prose(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        def fake_fm(prompt: str) -> str:
+            return json.dumps({
+                "title": "shell-spawning",
+                "trigger": "When the captain proposes more than 3 parallel shells.",
+                "anti_pattern": "Shells without a coordination plan.",
+                "symptoms": ["High shell count", "Tokens consumed coordinating shells"],
+                "remedy": "Consolidate shell work into a single dispatch.",
+                "related_orders": ["light-squadron"],
+            })
+
+        candidates = detect_candidate_orders(
+            memory_dir,
+            standing_orders_dir=so_dir,
+            min_missions=10,
+            fm_client=fake_fm,
+        )
+        assert candidates[0].source == "fm"
+        assert candidates[0].title == "shell-spawning"
+        assert candidates[0].remedy
+
+    def test_fm_malformed_falls_back_to_stub(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        def bad_fm(prompt: str) -> str:
+            return "not valid JSON at all"
+
+        candidates = detect_candidate_orders(
+            memory_dir,
+            standing_orders_dir=so_dir,
+            min_missions=10,
+            fm_client=bad_fm,
+        )
+        assert candidates[0].source == "heuristic-stub"
+
+    def test_fm_exception_falls_back_to_stub(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        def crashing_fm(prompt: str) -> str:
+            raise RuntimeError("FM down")
+
+        candidates = detect_candidate_orders(
+            memory_dir,
+            standing_orders_dir=so_dir,
+            min_missions=10,
+            fm_client=crashing_fm,
+        )
+        assert candidates[0].source == "heuristic-stub"
+
+    def test_parse_fm_response_strips_fences(self) -> None:
+        fenced = "```json\n{\"title\": \"foo\"}\n```"
+        parsed = _parse_fm_response(fenced)
+        assert parsed == {"title": "foo"}
+
+    def test_heuristic_stub_carries_evidence(self) -> None:
+        from nelson_data_patterns import RawPattern, ScoredPattern
+        raw = RawPattern(
+            cluster_id="abc123",
+            canonical_text="planted text",
+            variants=("planted text",),
+            mission_ids=("m1", "m2"),
+        )
+        sp = ScoredPattern(
+            raw=raw,
+            total_missions=10,
+            missions_with=2,
+            missions_without=8,
+            successes_with=0,
+            failures_with=2,
+            successes_without=8,
+            failures_without=0,
+            p_value=0.02,
+            correlation=-2.0,
+            confidence=0.98,
+            frequency_score=0.2,
+        )
+        stub = _heuristic_stub(sp)
+        assert "planted text" in stub["anti_pattern"]
+        assert stub["title"]
+
+
+# ---------------------------------------------------------------------------
+# Ranking
+# ---------------------------------------------------------------------------
+
+
+class TestRanking:
+    def test_high_confidence_high_novelty_ranks_first(self) -> None:
+        a = Candidate.from_dict({
+            "id": "cand-a",
+            "title": "a",
+            "pattern_fingerprint": "a",
+            "scores": {"confidence": 0.95, "novelty": 0.9},
+        })
+        b = Candidate.from_dict({
+            "id": "cand-b",
+            "title": "b",
+            "pattern_fingerprint": "b",
+            "scores": {"confidence": 0.95, "novelty": 0.1},
+        })
+        c = Candidate.from_dict({
+            "id": "cand-c",
+            "title": "c",
+            "pattern_fingerprint": "c",
+            "scores": {"confidence": 0.3, "novelty": 0.9},
+        })
+        ranked = rank_for_review([b, c, a])
+        # a (high conf, high nov) > b (high conf, low nov) > c (low conf, high nov)
+        assert [r.id for r in ranked] == ["cand-a", "cand-b", "cand-c"]
+
+
+# ---------------------------------------------------------------------------
+# Promotion and dismissal
+# ---------------------------------------------------------------------------
+
+
+def _seed_candidate(memory_dir: Path, candidate: Candidate) -> None:
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    queue_path = memory_dir / "candidate-standing-orders.json"
+    queue_path.write_text(
+        json.dumps({
+            "version": 1,
+            "updated_at": "2026-01-02T00:00:00Z",
+            "candidate_count": 1,
+            "candidates": [candidate.to_dict()],
+        }),
+        encoding="utf-8",
+    )
+
+
+def _make_candidate(**overrides) -> Candidate:
+    base = {
+        "id": "cand-test123",
+        "title": "echoing-decks",
+        "pattern_fingerprint": "test123",
+        "trigger": "When the admiral repeats orders rather than issuing fresh ones.",
+        "anti_pattern": (
+            "The admiral re-issues the same brief rather than diagnosing why the "
+            "first dispatch failed."
+        ),
+        "symptoms": ["Same brief dispatched twice", "Captain reports no progress"],
+        "remedy": "Diagnose first; only re-dispatch with a fixed brief.",
+        "related_orders": ["pulling-the-oar"],
+        "evidence_mission_ids": ["2026-01-01_000001", "2026-01-01_000002"],
+        "scores": {"confidence": 0.95, "novelty": 0.8},
+        "created_at": "2026-01-02T00:00:00Z",
+        "source": "fm",
+    }
+    base.update(overrides)
+    return Candidate.from_dict(base)
+
+
+class TestPromotion:
+    def test_promote_writes_well_formed_md(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "## Standing Orders\n\n"
+            "| Situation | Standing Order |\n"
+            "|---|---|\n"
+            "| Existing | `references/standing-orders/split-keel.md` |\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+
+        out_path = promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        assert out_path == so_dir / "echoing-decks.md"
+        text = out_path.read_text(encoding="utf-8")
+        assert "# Standing Order: Echoing Decks" in text
+        assert "**Trigger:**" in text
+        assert "**Symptoms:**" in text
+        assert "**Remedy:**" in text
+        assert "audit-lineage" in text
+        assert "2026-01-01_000001" in text
+
+    def test_promote_updates_skill_md_table(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "## Standing Orders\n\n"
+            "| Situation | Standing Order |\n"
+            "|---|---|\n"
+            "| Existing | `references/standing-orders/split-keel.md` |\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+
+        promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        updated = skill_md.read_text(encoding="utf-8")
+        assert "`references/standing-orders/echoing-decks.md`" in updated
+
+    def test_promote_removes_from_queue(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "| Situation | Standing Order |\n|---|---|\n"
+            "| Existing | `references/standing-orders/split-keel.md` |\n",
+            encoding="utf-8",
+        )
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+
+        promote_candidate(
+            cand.id,
+            memory_dir=memory_dir,
+            standing_orders_dir=so_dir,
+            skill_md_path=skill_md,
+        )
+        assert count_pending_candidates(memory_dir) == 0
+
+    def test_promote_refuses_overwrite(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        so_dir = _empty_standing_orders_dir(tmp_path)
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "| Situation | Standing Order |\n|---|---|\n"
+            "| Existing | `references/standing-orders/split-keel.md` |\n",
+            encoding="utf-8",
+        )
+        # Pre-existing hand-written order
+        (so_dir / "echoing-decks.md").write_text("hand-written", encoding="utf-8")
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+
+        try:
+            promote_candidate(
+                cand.id,
+                memory_dir=memory_dir,
+                standing_orders_dir=so_dir,
+                skill_md_path=skill_md,
+            )
+        except FileExistsError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("Expected FileExistsError")
+        # Hand-written content preserved
+        assert (so_dir / "echoing-decks.md").read_text(encoding="utf-8") == "hand-written"
+
+    def test_promote_unknown_candidate_raises(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        try:
+            promote_candidate(
+                "cand-missing",
+                memory_dir=memory_dir,
+                standing_orders_dir=_empty_standing_orders_dir(tmp_path),
+                skill_md_path=tmp_path / "SKILL.md",
+            )
+        except ValueError as exc:
+            assert "cand-missing" in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("Expected ValueError")
+
+
+class TestDismissal:
+    def test_dismiss_archives_candidate(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+
+        dismiss_candidate(cand.id, memory_dir=memory_dir, reason="too vague")
+        archive = json.loads(
+            (memory_dir / "dismissed-candidates.json").read_text(encoding="utf-8")
+        )
+        assert archive["dismissed_count"] == 1
+        assert archive["dismissed"][0]["pattern_fingerprint"] == cand.pattern_fingerprint
+        assert archive["dismissed"][0]["reason"] == "too vague"
+        assert count_pending_candidates(memory_dir) == 0
+
+    def test_dismiss_unknown_candidate_raises(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        try:
+            dismiss_candidate("cand-missing", memory_dir=memory_dir, reason="x")
+        except ValueError as exc:
+            assert "cand-missing" in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("Expected ValueError")
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests (subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_detect_patterns_empty_memory(self, tmp_path: Path) -> None:
+        result = run(
+            "detect-patterns",
+            "--memory-dir", str(tmp_path / ".nelson" / "memory"),
+            cwd=tmp_path,
+        )
+        assert "No patterns.json" in result.stdout
+
+    def test_detect_patterns_synthetic_dataset(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / ".nelson" / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        result = run(
+            "detect-patterns",
+            "--memory-dir", str(memory_dir),
+            "--standing-orders-dir", str(so_dir),
+            "--min-missions", "10",
+            "--confidence-threshold", "0.7",
+            cwd=tmp_path,
+        )
+        assert "Detected 1 new candidate" in result.stdout
+        queue = read_json(memory_dir / "candidate-standing-orders.json")
+        assert queue["candidate_count"] == 1
+
+    def test_dismiss_then_redetect_excludes_candidate(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / ".nelson" / "memory"
+        _make_patterns_file(
+            memory_dir, with_pattern_failing=4, without_pattern_succeeding=8
+        )
+        so_dir = _empty_standing_orders_dir(tmp_path)
+
+        run(
+            "detect-patterns",
+            "--memory-dir", str(memory_dir),
+            "--standing-orders-dir", str(so_dir),
+            "--min-missions", "10",
+            cwd=tmp_path,
+        )
+        queue = read_json(memory_dir / "candidate-standing-orders.json")
+        cid = queue["candidates"][0]["id"]
+
+        run(
+            "dismiss-candidate", cid,
+            "--reason", "duplicate of split-keel",
+            "--memory-dir", str(memory_dir),
+            cwd=tmp_path,
+        )
+        result = run(
+            "detect-patterns",
+            "--memory-dir", str(memory_dir),
+            "--standing-orders-dir", str(so_dir),
+            "--min-missions", "10",
+            cwd=tmp_path,
+        )
+        assert "Detected 0 new candidate" in result.stdout
+
+    def test_promote_unknown_candidate_exits_nonzero(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / ".nelson" / "memory"
+        memory_dir.mkdir(parents=True)
+        run(
+            "promote-candidate", "cand-missing",
+            "--memory-dir", str(memory_dir),
+            cwd=tmp_path,
+            expect_fail=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Intelligence brief surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestBriefSurfacing:
+    def test_brief_omits_line_when_zero_candidates(self, tmp_path: Path) -> None:
+        # Build an index from a single completed mission so the brief has body
+        from conftest import create_completed_mission
+        create_completed_mission(tmp_path, mission_id="2026-03-29_100000")
+        run(
+            "index", "--missions-dir", str(tmp_path / ".nelson" / "missions"),
+            cwd=tmp_path,
+        )
+        result = run("brief", "--missions-dir", str(tmp_path / ".nelson" / "missions"), cwd=tmp_path)
+        assert "CANDIDATE STANDING ORDERS" not in result.stdout
+
+    def test_brief_includes_line_when_candidate_present(self, tmp_path: Path) -> None:
+        from conftest import create_completed_mission
+        create_completed_mission(tmp_path, mission_id="2026-03-29_100000")
+        run(
+            "index", "--missions-dir", str(tmp_path / ".nelson" / "missions"),
+            cwd=tmp_path,
+        )
+        memory_dir = tmp_path / ".nelson" / "memory"
+        memory_dir.mkdir(parents=True, exist_ok=True)
+        cand = _make_candidate()
+        _seed_candidate(memory_dir, cand)
+
+        result = run("brief", "--missions-dir", str(tmp_path / ".nelson" / "missions"), cwd=tmp_path)
+        assert "CANDIDATE STANDING ORDERS (awaiting review): 1" in result.stdout


### PR DESCRIPTION
## Summary
- Adds a Darwin Gödel Machine-inspired pipeline (`skills/nelson/scripts/nelson_data_patterns.py`) that mines `avoid` patterns from accumulated mission data, scores them with Fisher's exact + log-odds, filters against existing orders and a dismissed archive, and synthesises candidate standing orders for human review (with a heuristic-stub fallback when no FM client is wired).
- Wires three new CLI subcommands into `nelson-data.py`: `detect-patterns`, `promote-candidate`, `dismiss-candidate`. Promotion writes a new `.md` under `references/standing-orders/` with an audit-lineage comment and adds a row to the SKILL.md lookup table; dismissal archives the fingerprint so re-runs cannot resurface it.
- Surfaces `CANDIDATE STANDING ORDERS (awaiting review): N` in the Intelligence Brief (text + JSON) when the queue is non-empty.
- 35 new tests in `test_nelson_data_patterns.py`; full Python suite remains green (338 passing).

Closes #87.

## Design notes
- Ranking is `confidence × (1 + novelty)` rather than the plan's `sigmoid(confidence) × (1 + novelty)`. Sigmoid maps `[0, 1]` confidence into `[0.5, 0.73]` — too compressed to discriminate when novelty's range is `[1, 2]`. Documented inline in `_review_score`.
- Novelty uses **token containment** (fraction of a pattern's tokens covered by an existing order) rather than TF-IDF Jaccard — better fit for short avoid-phrases vs. full standing-order documents.
- **Add-only invariant**: candidates may never modify or remove existing orders — mitigates the objective-hacking failure mode in DGM Appendix H (node 114 deleting hallucination-detection tokens to game the metric).
- `detect-patterns` skips writing an empty queue file on first runs to avoid littering the memory dir.

## Test plan
- [x] `pytest skills/nelson/scripts/test_nelson_data_patterns.py` — 35/35 pass
- [x] Full suite `pytest skills/nelson/scripts/` — 338/338 pass
- [x] `ruff check` clean on new code
- [x] Integration on real worktree data (1 mission, below `min_missions=10`) — 0 candidates, no crash, no empty file
- [x] Synthetic 12-mission dataset — 1 candidate detected at confidence 0.998
- [x] Dismiss → re-detect — pattern not resurfaced
- [x] Promote — writes well-formed `.md` (header / Trigger / Symptoms / Remedy / Related orders / audit lineage) and appends row to SKILL.md table
- [x] FM-malformed-response and FM-raises-exception paths both fall back to the heuristic stub
- [x] Brief surfaces the candidate count when present and omits the line cleanly when zero