### PR TITLE
chore: backlog triage delivery — admiralty-decision docs, sidecar cleanup, incremental mypy sensor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,17 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: d2823d321df3af8f878f7ee3414dc94d037145b9  # frozen: v2.1.0
+    hooks:
+      - id: mypy
+        name: mypy (strict, per-module rollout — nelson-8q8)
+        # Allow-list: only modules already proven strict-clean. Grow this
+        # regex together with the [tool.mypy] overrides in pyproject.toml as
+        # each module is migrated. Keeps the sensor from blocking commits on
+        # the ~99 pre-existing lenient errors elsewhere in the tree.
+        files: ^skills/nelson/scripts/nelson_circuit_breakers\.py$
+
   - repo: https://github.com/gitleaks/gitleaks
     rev: 2ca41cc1372d1e939a6a879f18cdc19fc1cac1ce  # frozen: v8.30.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,38 @@ max-complexity = 10
 [tool.ruff.format]
 docstring-code-format = true
 
-# mypy: roll-out tracked under nelson-8q8
+# ---------------------------------------------------------------------------
+# mypy — Tier 1.5 type sensor, rolled out per-module (nelson-8q8).
+#
+# Why allow-list, not repo-wide: a full lenient run currently reports ~99
+# errors across 6 modules (root cause: _read_json returns `dict | list` and
+# callers treat it as `dict`). Turning mypy on repo-wide would block every
+# commit and derail agents — the exact failure the bead warns about.
+#
+# Mechanism: the base config below is lenient; strict is enabled per-module
+# via the overrides block, and the pre-commit hook's `files:` allow-list (see
+# .pre-commit-config.yaml) only checks modules already proven strict-clean.
+# Add a module to BOTH lists once it passes `mypy --strict`. End state:
+# `strict = true` repo-wide, then this scaffolding collapses to one line.
+#
+# Migrated (strict-clean): nelson_circuit_breakers. The remaining modules and
+# the next candidate are tracked in beads nelson-8q8 (kept there, not here, so
+# this comment can't rot as the rollout proceeds).
+# ---------------------------------------------------------------------------
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true   # cross-dir imports use runtime sys.path shims
+
+[[tool.mypy.overrides]]
+module = "nelson_circuit_breakers"
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unused_ignores = true
+strict_equality = true
+disallow_any_generics = true
 
 # ---------------------------------------------------------------------------
 # Tests + coverage.

--- a/skills/nelson/references/structured-data.md
+++ b/skills/nelson/references/structured-data.md
@@ -132,6 +132,31 @@ python3 .claude/skills/nelson/scripts/nelson-data.py checkpoint \
   --rationale "On track. HMS Kent approaching amber but no relief needed yet."
 ```
 
+### `admiralty-decision` — Record an admiral's action decision (read/write mission log)
+
+Run when the admiral approves, modifies, or rejects an `admiralty_action_required` item raised during the mission (typically around a checkpoint). Feeds the override-learned trust calibration that aggregates at `stand-down`.
+
+Appends an `admiralty_action_completed` event to `mission-log.json`. The event `data` records `task_id`, `decision_type`, `recorded_by`, and `session_marker_present`; it also resolves `task_type` (from `battle-plan.json`) and `ship_class` (from the task owner's squadron in `fleet-status.json`) when those are available.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py admiralty-decision \
+  --mission-dir .nelson/missions/2026-03-27_120000_a1b2c3d4 \
+  --task-id 3 \
+  --decision-type modified \
+  --recorded-by Admiral \
+  --notes "Narrowed scope to the auth module only"
+```
+
+Arguments:
+
+- `--mission-dir` (required) — Mission directory path.
+- `--task-id` (required, int) — Task the decision applies to; must exist in `battle-plan.json`.
+- `--decision-type` (required) — One of `approved`, `modified`, `rejected`.
+- `--recorded-by` (required) — Ship that recorded the decision (e.g. `Admiral` or a captain's ship name). Captured into `data.recorded_by` for audit provenance; an empty value is rejected.
+- `--notes` (optional) — Free-text rationale, stored in `data.notes` when non-empty.
+
+`session_marker_present` captures whether the admiral session marker existed at record time, so the calibration pipeline can distinguish admiral-confirmed decisions from self-reported ones.
+
 ### `stand-down` — Record mission completion
 
 Run at Step 6 alongside the prose captain's log.
@@ -461,7 +486,7 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py set \
 | `standing_order_violation` | Standing order triggered | order, description, corrective_action, severity |
 | `commendation` | Signal flag or MID | ship_name, type, citation |
 | `admiralty_action_required` | Task needs human input | task_id, action, timing |
-| `admiralty_action_completed` | Human completed action | task_id, resolution |
+| `admiralty_action_completed` | Admiral decision recorded (via `admiralty-decision`) | task_id, decision_type, recorded_by, session_marker_present (+ optional task_type, ship_class, notes) |
 | `battle_plan_amended` | Admiral rescopes | changes, rationale |
 | `phase_transition` | Phase engine advances | from_phase, to_phase |
 | `phase_override` | Manual phase set (recovery) | from_phase, to_phase |

--- a/skills/nelson/scripts/nelson_data_lifecycle.py
+++ b/skills/nelson/scripts/nelson_data_lifecycle.py
@@ -1190,6 +1190,18 @@ def cmd_stand_down(args: argparse.Namespace) -> None:  # noqa: C901, PLR0912, PL
     except OSError:
         pass
 
+    # Best-effort cleanup of the .active-<session_id> recovery sidecar written
+    # by _do_init. The mission dir is named "{stamp}_{session_id}", so the
+    # session id is the trailing segment. Without this, stale markers
+    # accumulate in .nelson/ across missions (nelson-a06).
+    session_id = mission_dir.name.rsplit("_", 1)[-1]
+    try:
+        (mission_dir.parent.parent / f".active-{session_id}").unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
     # Print mission summary
     achieved = "ACHIEVED" if args.outcome_achieved else "NOT ACHIEVED"
     print(

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -938,6 +938,51 @@ class TestStandDown:
             "Pass",
         )
 
+    def test_removes_active_sidecar(self, tmp_path: Path) -> None:
+        """The .active-<session_id> recovery sidecar is cleaned up at stand-down."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        add_task(mission_dir)
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        session_id = mission_dir.name.rsplit("_", 1)[1]
+        sidecar = tmp_path / ".nelson" / f".active-{session_id}"
+        assert sidecar.exists()
+        run(
+            "stand-down",
+            "--mission-dir",
+            str(mission_dir),
+            "--outcome-achieved",
+            "--actual-outcome",
+            "Done",
+            "--metric-result",
+            "Pass",
+        )
+        assert not sidecar.exists()
+
+    def test_stand_down_succeeds_without_active_sidecar(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Cleanup is best-effort: a missing sidecar must not fail stand-down."""
+        mission_dir = init_mission(tmp_path)
+        add_squadron(mission_dir)
+        add_task(mission_dir)
+        run("plan-approved", "--mission-dir", str(mission_dir))
+        session_id = mission_dir.name.rsplit("_", 1)[1]
+        sidecar = tmp_path / ".nelson" / f".active-{session_id}"
+        sidecar.unlink()
+        assert not sidecar.exists()
+        run(
+            "stand-down",
+            "--mission-dir",
+            str(mission_dir),
+            "--outcome-achieved",
+            "--actual-outcome",
+            "Done",
+            "--metric-result",
+            "Pass",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Status


### PR DESCRIPTION
## Summary

Delivers three triaged-and-approved backlog beads. Each was verified against the current code, implemented minimally (anti-bloat), adversarially reviewed (0 critical/high/medium findings), and run through the repo sensors.

| Bead | Commit | Change |
|------|--------|--------|
| **nelson-bws** | `8386c19` | Document the `admiralty-decision` subcommand in `structured-data.md` (incl. the required `--recorded-by` provenance arg) and fix the stale `admiralty_action_completed` event-table row (`task_id, resolution` → the real emitted fields). Docs-only. |
| **nelson-a06** | `eb35030` | `cmd_stand_down` now unlinks the `.nelson/.active-<session_id>` recovery sidecar (idempotent, mirrors the adjacent admiral-marker cleanup), so stale markers no longer accumulate. +2 regression tests. The `_find_active_mission` "symlink files" docstring was already fixed in an earlier change. |
| **nelson-8q8** | `c60053a` | Wire mypy as a **check-only** pre-commit sensor, rolled out **per-module via an allow-list** rather than repo-wide. First strict-clean module: `nelson_circuit_breakers`. |

### Why mypy is scoped, not repo-wide
A full lenient mypy run currently surfaces **~99 errors across 6 modules** (root cause: `_read_json` returns `dict | list` and callers treat it as `dict`). A repo-wide hook — even lenient — would block every commit and derail agents, the exact failure the bead warns about. So the base `[tool.mypy]` config is lenient, strict is enabled per-module via overrides + the pre-commit `files:` allow-list, and the rollout (next: `nelson_data_utils`, 18 errors; end state `strict = true` repo-wide) is tracked in **nelson-8q8** (kept open).

## Triage context
This branch is the delivery half of a backlog grooming pass over 9 open beads. Also closed (no code, decision-only): `nelson-6bw` (already done), `nelson-7rm` + `nelson-q96` (Tier 2/3 sensors — over-engineering for a skill repo), `nelson-h4g` (Pi harness — not pursued). Kept as backlog: `nelson-e6j`, `nelson-y2l`, and `nelson-8q8` (rollout tracker).

## Test plan
- [x] `pytest skills/nelson/scripts/` — 384 passed (incl. 2 new sidecar tests; confirmed RED before fix)
- [x] `pytest hooks/` — 64 passed
- [x] `pytest scripts/` — 21 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `markdownlint-cli2` on the changed doc — 0 errors
- [x] `pre-commit run --files <changed>` — all hooks pass
- [x] mypy hook passes strict on `nelson_circuit_breakers` and skips all other files