### PR TITLE
feat: align Nelson with Claude Code dynamic workflows (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Claude Code dynamic workflows move orchestration into workflow scripts that can 
 
 `ultracode` is treated as a Claude Code `xhigh` effort/automation setting, not a Nelson execution mode. If ultracode or the user chooses a workflow, Nelson still supplies the mission charter, risk tiering, human gates, telemetry expectations, and fallback mode.
 
+### Standing goals
+
+For long autonomous, headless, or scheduled runs, Nelson aligns with Claude Code's [`/goal`](https://code.claude.com/docs/en/goal) — a session-scoped Stop hook that keeps the session from stopping until a completion condition is met. Nelson composes the condition from the sailing orders (`nelson-data.py goal-condition`) so it stays tied to the mission's outcome, metric, and stop criteria, and phrases it against what the goal evaluator can actually see: the conversation transcript. The standing goal and Nelson's Mission Complete Gate reinforce each other — the gate is the discipline the admiral applies, the goal is the harness backstop that enforces it. See `references/goal-alignment.md`.
+
 ### Chain of command
 
 Nelson uses a three-tier hierarchy. The admiral coordinates captains, each captain commands a named ship, and crew members aboard each ship do the specialist work.
@@ -451,6 +455,7 @@ skills/nelson/
 │   ├── admiralty-templates/      # 11 structured templates
 │   ├── crew-roles.md             # Crew role definitions & ship names
 │   ├── damage-control/           # 11 recovery procedures
+│   ├── goal-alignment.md         # Claude Code /goal (standing goal) doctrine
 │   ├── standing-orders/          # 16 anti-pattern guards
 │   ├── the-estimate.md           # 7 Question Maritime Tactical Estimate reference
 │   ├── squadron-composition.md   # Mode selection & team sizing
@@ -488,6 +493,7 @@ skills/nelson/
 │   │   └── turnover-brief.md
 │   ├── commendations.md                       # Recognition signals and correction guidance
 │   ├── crew-roles.md                         # Crew role definitions, ship names, sizing
+│   ├── goal-alignment.md                     # Claude Code /goal (standing goal) doctrine
 │   ├── damage-control/                       # Individual procedure files
 │   │   ├── circuit-breakers.md
 │   │   ├── comms-failure.md
@@ -529,6 +535,7 @@ skills/nelson/
     ├── nelson_data_utils.py                  # Shared I/O, validation, constants
     ├── nelson_data_memory.py                 # Cross-mission memory store (v2.0.0)
     ├── nelson_data_lifecycle.py              # Mission lifecycle commands
+    ├── nelson_data_goal.py                   # Composes a Claude Code /goal condition
     ├── nelson_data_fleet.py                  # Fleet intelligence & analytics
     ├── nelson_conflict_scan.py               # Pre-flight split-keel scanner
     ├── nelson_conflict_radar.py              # Runtime file-conflict monitor

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Nelson gives Claude an eight-step operational framework for tackling complex mis
 1. **Sailing Orders** — Define the outcome, success metric, constraints, and stop criteria
 2. **The Estimate** — Conduct the 7 Question Maritime Tactical Estimate: reconnaissance, intent, effects, terrain, forces, coordination, and control
 3. **Battle Plan** — Turn approved effects into task assignments with owners, dependencies, and file ownership
-4. **Form the Squadron** — Choose an execution mode (single-session, subagents, or agent team) and size the team
+4. **Form the Squadron** — Choose an execution mode (single-session, subagents, agent team, workflow, or hybrid workflow) and size the team
 5. **Get Permission to Sail** — Present the plan for user approval before committing resources
 6. **Quarterdeck Rhythm** — Run checkpoints to track progress, identify blockers, monitor hull integrity, and manage budget
 7. **Action Stations** — Classify tasks by risk tier and enforce verification before marking complete
@@ -103,13 +103,21 @@ If you need fast parallel execution with minimal ceremony, [OmO](https://github.
 
 ### Execution modes
 
-The skill selects one of three execution modes based on your mission:
+The skill selects one of five execution modes based on your mission:
 
 | Mode | When to use | How it works |
 |------|------------|--------------|
 | `single-session` | Sequential tasks, low complexity, heavy same-file editing | Claude works through tasks in order within one session |
 | `subagents` | Parallel tasks where workers only report back to the coordinator | Claude spawns [subagents](https://code.claude.com/docs/en/sub-agents) that work independently and return results |
 | `agent-team` | Parallel tasks where workers need to coordinate with each other | Claude creates an [agent team](https://code.claude.com/docs/en/agent-teams) with direct teammate-to-teammate communication |
+| `workflow` | Large fan-out audits, repeatable migrations, codebase-wide analysis, or cross-checked research | Nelson writes a Workflow Charter and verification contract for one approved [dynamic workflow](https://code.claude.com/docs/en/workflows) run |
+| `hybrid-workflow` | Workflow-suitable missions that need probes, Station 2/3 controls, or human approval between stages | Nelson gates a sequence of separate workflow runs, reviewing telemetry and outputs before the next stage |
+
+### Dynamic workflows and ultracode
+
+Claude Code dynamic workflows move orchestration into workflow scripts that can fan out to many agents, keep intermediate results in script state, and aggregate broad review or migration results. Nelson does not replace that mechanism. Nelson wraps it with doctrine: Sounding-the-Channel probes, explicit permission gates, cost guardrails, audit logs, and verification contracts before findings or edits are accepted.
+
+`ultracode` is treated as a Claude Code `xhigh` effort/automation setting, not a Nelson execution mode. If ultracode or the user chooses a workflow, Nelson still supplies the mission charter, risk tiering, human gates, telemetry expectations, and fallback mode.
 
 ### Chain of command
 
@@ -379,7 +387,7 @@ Nelson is a Claude Code skill — it loads automatically when your request match
 
 ### Let Nelson pick the execution mode
 
-Nelson selects the best execution mode (single-session, subagents, or agent team) based on your mission:
+Nelson selects the best execution mode (single-session, subagents, agent team, workflow, or hybrid workflow) based on your mission:
 
 ```
 Use Nelson to migrate the payment processing module from Stripe v2 to v3
@@ -445,7 +453,8 @@ skills/nelson/
 │   ├── damage-control/           # 11 recovery procedures
 │   ├── standing-orders/          # 16 anti-pattern guards
 │   ├── the-estimate.md           # 7 Question Maritime Tactical Estimate reference
-│   └── squadron-composition.md   # Mode selection & team sizing
+│   ├── squadron-composition.md   # Mode selection & team sizing
+│   └── workflow-doctrine.md      # Dynamic workflow & ultracode doctrine
 └── scripts/              # nelson-data.py, conflict scan, circuit breakers, tests
 ```
 
@@ -497,6 +506,7 @@ skills/nelson/
 │   ├── structured-data.md                    # Structured fleet data capture reference
 │   ├── the-estimate.md                       # 7 Question Maritime Tactical Estimate reference
 │   ├── tool-mapping.md                       # Nelson-to-Claude Code tool reference
+│   ├── workflow-doctrine.md                  # Dynamic workflow and ultracode doctrine
 │   └── standing-orders/                      # Individual anti-pattern files
 │       ├── admiral-at-the-helm.md
 │       ├── all-hands-on-deck.md
@@ -568,11 +578,11 @@ Nelson writes two kinds of artifacts side by side: **prose** for humans (captain
 
 ### Platform support
 
-Nelson requires **agent-team coordination primitives** — shared task lists, peer messaging between agents, and team lifecycle management. These are the foundation of Nelson's squadron model: captains coordinating in parallel, the admiral running quarterdeck checkpoints, and damage control procedures that depend on live communication between agents.
+Nelson is built around **Claude Code orchestration primitives** — shared task lists, peer messaging between agents, subagents, and dynamic workflows. These are the foundation of Nelson's squadron model: captains coordinating in parallel, the admiral running quarterdeck checkpoints, and damage control procedures that keep modern Claude Code orchestration auditable.
 
 | Platform | Status | Notes |
 |----------|--------|-------|
-| **Claude Code** | Supported | Full support for all three execution modes (single-session, subagents, agent-team) |
+| **Claude Code** | Supported | Full support for all five execution modes (single-session, subagents, agent-team, workflow, hybrid-workflow) |
 | **Cursor** | Experimental | See installation instructions above |
 | **Codex CLI** | Not yet supported | Lacks agent-team primitives. [Agents SDK](https://openai.github.io/openai-agents-python/) orchestration may provide a path — monitoring |
 | **OpenCode** | Not yet supported | Agent-team feature exists on dev branch but has not reached stable release |

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -25,6 +25,7 @@ skills/nelson/
     structured-data.md      — Structured fleet data capture reference
     the-estimate.md         — 7 Question Maritime Tactical Estimate reference
     tool-mapping.md         — Nelson-to-Claude Code tool reference
+    workflow-doctrine.md    — Dynamic workflow and ultracode doctrine
     admiralty-templates/    — One file per template, loaded on demand
       battle-plan.md            — Battle plan with commander's intent and acceptance criteria
       captains-log.md           — Final mission report

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -19,6 +19,7 @@ skills/nelson/
     action-stations.md      — Risk tier definitions (Station 0–3)
     commendations.md        — Recognition signals & graduated correction
     crew-roles.md           — Crew role definitions, ship names & sizing rules
+    goal-alignment.md       — Claude Code /goal (standing goal) doctrine
     model-selection.md      — Cost-optimized model assignment for agents
     royal-marines.md        — Royal Marines deployment rules & specialisations
     squadron-composition.md — Mode selection & team sizing rules
@@ -69,6 +70,7 @@ skills/nelson/scripts/    — Skill-level scripts (run by Nelson itself)
   nelson_data_utils.py      — Shared I/O, validation, and constants
   nelson_data_memory.py     — Cross-mission memory store and pattern library
   nelson_data_lifecycle.py  — Mission lifecycle commands (init through status)
+  nelson_data_goal.py       — Composes a Claude Code /goal condition from sailing orders
   nelson_data_fleet.py      — Fleet intelligence and analytics commands
   nelson_data_patterns.py   — Learned standing orders pipeline (mine → score → synthesise)
   nelson_circuit_breakers.py — Automated alarm thresholds (hull, budget, idle, blockers)
@@ -76,6 +78,7 @@ skills/nelson/scripts/    — Skill-level scripts (run by Nelson itself)
   nelson_conflict_scan.py   — Conflict scan CLI
   conftest.py               — Shared test helpers (pytest auto-discovery)
   test_nelson_data.py       — Lifecycle command tests
+  test_nelson_data_goal.py  — Goal-condition composer and CLI tests
   test_nelson_data_fleet.py — Fleet intelligence and analytics tests
   test_nelson_data_memory.py — Memory store and I/O tests
   test_nelson_data_patterns.py — Learned standing orders pipeline tests

--- a/hooks/test_nelson_hooks.py
+++ b/hooks/test_nelson_hooks.py
@@ -757,6 +757,18 @@ class TestSessionCheck:
         )
         assert code == 0
 
+    def test_workflow_modes_allow_workflow_contexts(self, tmp_path: Path) -> None:
+        """Workflow modes are not captain-gated like subagents/single-session."""
+        for mode in ("workflow", "hybrid-workflow"):
+            _make_mission(tmp_path, mode=mode)
+            _write_marker(tmp_path, "/admiral.jsonl")
+            code = _run(
+                cmd_session_check,
+                {"transcript_path": f"/{mode}-runner.jsonl"},
+                cwd=str(tmp_path),
+            )
+            assert code == 0
+
 
 # ---------------------------------------------------------------------------
 # Preflight admiral-marker backfill

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -111,6 +111,8 @@ When The Estimate has been conducted, the Battle Plan inherits the analytical wo
 
 Reference `references/admiralty-templates/battle-plan.md` for the schema of each captain's brief and `references/admiralty-templates/ship-manifest.md` for the ship manifest.
 
+**Workflow Suitability Check:** If the mission has large fan-out, repeatable orchestration, codebase-wide analysis, broad migrations, audits, or cross-checking needs, you MUST read `references/workflow-doctrine.md` and decide whether `workflow` or `hybrid-workflow` is appropriate. For workflow modes, add a compact Workflow Charter to the battle plan with execution primitive, suitability, phases, human gates, verification contract, cost guardrail, and fallback mode. For non-workflow modes, include one line: `Workflow suitability: not selected because ...`. Station 2/3 workflow work should default to `hybrid-workflow` because human approval belongs between separate workflow runs, not inside one arbitrary mid-run pause.
+
 **Battle Plan Gate — Standing Order Check:** You MUST NOT finalize task assignments until each question below is answered in writing and any triggered standing order remedy has been applied. Show your reasoning — a bare yes/no is not sufficient.
 - `becalmed-fleet.md`: Should this mission use single-session instead of multi-agent? If yes, skip Step 4 — single-session has no squadron to form.
 - `light-squadron.md`: Is the task count equal to the number of independent work units, or have tasks been under-split?
@@ -137,13 +139,17 @@ If any answer triggers a standing order, you MUST apply the corrective action an
     - `single-session`: sequential tasks, low complexity, or heavy same-file editing.
     - `subagents`: parallel, fully independent tasks that report only to the admiral.
     - `agent-team`: captains benefit from a shared task list, peer messaging, or coordinated deliverables; or 4+ captains are needed.
+    - `workflow`: one autonomous dynamic workflow run for large fan-out, repeatable review, broad migration, audit, or cross-checked research.
+    - `hybrid-workflow`: Nelson-gated sequence of workflow stages with human approval between stages.
 
 **Mode-Tool Consistency Gate:** Before assigning ships, confirm your tool usage matches the selected mode by reviewing `references/tool-mapping.md`:
 - **`subagents` mode:** Captains do NOT use `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, or `SendMessage(type="message")`. Captains report via the `Agent` tool return value only. The admiral uses `TaskCreate`/`TaskUpdate`/`TaskList` to track progress in the session task list (visibility only — captains cannot see these tasks).
 - **`agent-team` mode:** Do NOT use `Agent` with `subagent_type` to spawn captains (marines still use `subagent_type`). Use `TeamCreate` first, then `Agent` with `team_name` + `name`. Coordinate via `TaskList` and `SendMessage`.
 - **`single-session` mode:** The admiral uses `TaskCreate`, `TaskUpdate`, `TaskList`, and `TaskGet` to track progress as it completes each task sequentially.
+- **`workflow` mode:** Treat the workflow as a fleet asset, not ordinary captains. Nelson v1 produces a Workflow Charter/prompt and telemetry plan; it does not directly invoke a workflow API or generate runnable `.claude/workflows/*.js`.
+- **`hybrid-workflow` mode:** Treat each workflow stage as a separate fleet asset. Stop at the planned gate, present results, and launch the next workflow run only after explicit approval.
 
-**Task List Visibility:** After selecting the execution mode, create a `TaskCreate` entry for each battle plan task to make mission progress visible in the Claude Code task list (Ctrl+T). This applies in **all execution modes** — it is admiral-level visibility tracking, not inter-agent coordination.
+**Task List Visibility:** After selecting the execution mode, create a `TaskCreate` entry for each battle plan task to make mission progress visible in the Claude Code task list (Ctrl+T). This applies in **all execution modes** — it is admiral-level visibility tracking, not inter-agent coordination. In `workflow` and `hybrid-workflow`, also create visibility entries for workflow phases or gates when they are the operational units being tracked.
 
 For each task:
 - `subject`: Task name from the battle plan (imperative form, e.g., "Refactor auth module")
@@ -160,7 +166,7 @@ All tasks start as `pending`. They will be updated with owners and status as the
 ```
 SQUADRON FORMATION ORDERS
 
-Mode: [single-session | subagents | agent-team]
+Mode: [single-session | subagents | agent-team | workflow | hybrid-workflow]
 Captain count: [N]
 
 Ships:
@@ -169,6 +175,19 @@ Ships:
   [repeat for each ship]
 
 [Red-cell navigator — HMS X, if present]
+```
+
+For `workflow` and `hybrid-workflow`, include:
+
+```
+WORKFLOW CHARTER
+Execution primitive: [workflow | hybrid-workflow]
+Suitability: [why dynamic workflow orchestration is justified]
+Phases: [probe / full run / stage names]
+Human gates: [approval points, especially for hybrid-workflow]
+Verification contract: [how accepted, rejected, and uncertain findings are handled]
+Cost guardrail: [Sounding-the-Channel probe, scope cap, token/time stop]
+Fallback mode: [agent-team | single-session]
 ```
 
 If any tasks are marked `admiralty-action-required: yes`, append before awaiting approval:
@@ -184,7 +203,7 @@ ADMIRALTY ACTION LIST — Actions required from Admiralty
 Actions marked `timing: before task starts` require your sign-off before the relevant captain is spawned.
 ```
 
-Do not spawn any agents or create any tasks until the user approves. If the user requests changes, revise and redisplay before proceeding.
+Do not spawn any agents, create any tasks, or launch any `workflow` / `hybrid-workflow` run until the user approves. If the user requests changes, revise and redisplay before proceeding.
 
 > **Note:** For headless and CI invocation, use `nelson-data.py headless --auto-approve` which combines Steps 1-3 and skips the interactive approval gate. See `references/structured-data.md` for details.
 
@@ -217,6 +236,8 @@ This registers all tasks, records the squadron, computes DAG metrics, and runs t
 - **`agent-team` mode:** Use `TaskUpdate` to set `owner` to each captain's name and `status` to `in_progress` as captains are spawned. The team's shared task list now serves both visibility and coordination.
 - **`subagents` mode:** Use `TaskUpdate` to set `status` to `in_progress` as each captain is dispatched. The admiral tracks these directly.
 - **`single-session` mode:** Use `TaskUpdate` to set `status` to `in_progress` as the admiral begins each task.
+- **`workflow` mode:** Use `TaskUpdate` to mark the workflow run or phase as `in_progress`, and log `workflow_run_started`.
+- **`hybrid-workflow` mode:** Use `TaskUpdate` to mark only the currently approved workflow stage as `in_progress`; later stages remain `pending` until their human gate is passed.
 
 **Edit permissions:** When spawning any agent whose task involves editing files, set `mode: "acceptEdits"` on the `Agent` tool call. Omitting this can cause a permission race condition that silently stalls the agent at its first edit. When in doubt, include it.
 
@@ -227,7 +248,8 @@ This registers all tasks, records the squadron, computes DAG metrics, and runs t
 **Display and Permission Gate:**
 1. Display the complete battle plan to the user if `becalmed-fleet.md` is in effect.
 2. Display the complete squadron formation to the user if `becalmed-fleet.md` is not in effect. The battle plan (drafted in Step 3) should also be available for review.
-3. You are REQUIRED to wait for explicit permission to proceed.
+3. If `workflow` or `hybrid-workflow` is selected, display the Workflow Charter, verification contract, cost guardrail, fallback mode, and next human gate.
+4. You are REQUIRED to wait for explicit permission to proceed. Workflow and hybrid-workflow modes require explicit approval before every launch; for `hybrid-workflow`, repeat this gate between stages.
 
 **Phase Advance:** After the user grants permission, log the event and advance:
 
@@ -262,6 +284,7 @@ If the task is complete and no pending task depends on it, proceed to shutdown p
     - Check for active marine deployments; verify marines have returned and outputs are incorporated.
     - Safety net: if any idle ship with a complete task was missed between checkpoints, apply the `references/standing-orders/paid-off.md` shutdown procedure now before continuing.
     - Track burn against token/time budget.
+    - For `workflow` and `hybrid-workflow`, record workflow telemetry when available: phase, agents complete/total, token burn, elapsed time, failed agents, accepted findings, rejected findings, uncertain findings, and next gate. Use `workflow_probe_completed`, `workflow_run_completed`, or `workflow_run_stopped` events as appropriate.
     - Check hull integrity: collect damage reports from all ships, update the squadron readiness board, and take action per `references/damage-control/hull-integrity.md`. The admiral must also check its own hull integrity at each checkpoint. **Every ship must file a damage report at every checkpoint** to `{mission-dir}/damage-reports/{ship-name}.json` using the schema in `references/admiralty-templates/damage-report.md` — do not skip this when hull is Green.
     - Standing order scan: For each order below, ask "Has this situation arisen since the last checkpoint?" If yes, apply the corrective action now — do not defer.
         - `admiral-at-the-helm.md`: Has the admiral drifted into implementation work (excluding permitted read-only recombination)?
@@ -299,6 +322,7 @@ Reference `references/tool-mapping.md` for coordination tools, `references/admir
     - Test or validation output.
     - Failure modes and rollback notes.
     - Red-cell review for medium+ station tiers.
+- For `workflow` and `hybrid-workflow`, require the battle plan's verification contract before accepting workflow outputs. Accepted findings need the promised evidence, rejected or uncertain findings must be surfaced separately, and Station 2+ outputs still require adversarial review or human confirmation per `references/action-stations.md`.
 - Trigger quality checks on:
     - Task completion.
     - Agent idle with unverified outputs.

--- a/skills/nelson/SKILL.md
+++ b/skills/nelson/SKILL.md
@@ -37,7 +37,7 @@ Out of scope: Migration script for existing sessions
 
 **Establish Mission Directory:**
 - **New session:** Run `nelson-data.py init` (see "Structured Data Capture" below). The script owns directory creation: it generates an 8-character hex SESSION_ID, creates `.nelson/missions/{YYYY-MM-DD_HHMMSS}_{SESSION_ID}/` with the `damage-reports/` and `turnover-briefs/` subdirectories, writes `sailing-orders.json`, `mission-log.json`, and `fleet-status.json`, writes `.nelson/.active-{SESSION_ID}` as the session marker, and prints the mission directory path to stdout. Capture that path as `{mission-dir}` for the remainder of this mission. The SESSION_ID is the segment after the last underscore in the directory name. If you need a specific SESSION_ID (e.g., testing or resuming a known id), pass `--session-id <8-hex>`.
-- **Resumed session:** First, attempt auto-recovery by running `python3 .claude/skills/nelson/scripts/nelson-data.py recover --missions-dir .nelson/missions`. If this finds an active mission with handoff packets, use the structured recovery briefing to resume directly. Otherwise, if you know the SESSION_ID, read `.nelson/.active-{SESSION_ID}` to recover the mission path. Set that path as `{mission-dir}`. If you cannot determine your SESSION_ID (e.g., after a full restart), list `.nelson/missions/` and present the options to the user for selection. Set the chosen directory as `{mission-dir}`. Recover state per `references/damage-control/session-resumption.md` (prefer JSON files, fall back to quarterdeck report prose).
+- **Resumed session:** First, attempt auto-recovery by running `python3 .claude/skills/nelson/scripts/nelson-data.py recover --missions-dir .nelson/missions`. If this finds an active mission with handoff packets, use the structured recovery briefing to resume directly. Otherwise, if you know the SESSION_ID, read `.nelson/.active-{SESSION_ID}` to recover the mission path. Set that path as `{mission-dir}`. If you cannot determine your SESSION_ID (e.g., after a full restart), list `.nelson/missions/` and present the options to the user for selection. Set the chosen directory as `{mission-dir}`. Recover state per `references/damage-control/session-resumption.md` (prefer JSON files, fall back to quarterdeck report prose). **Re-establish the standing goal:** a `/goal` is restored automatically on `--resume`/`--continue` but not in a fresh session, so if none is active (check with a bare `/goal`) and `sailing-orders.json` carries a recorded `goal_condition`, re-issue it per `references/goal-alignment.md`.
 
 All mission artifacts — captain's log, quarterdeck reports, damage reports, and turnover briefs — are written inside `{mission-dir}`.
 
@@ -50,6 +50,15 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py advance --mission-dir {mis
 ```
 
 **Session Hygiene:** Execute session hygiene per `references/damage-control/session-hygiene.md`. Skip this step when resuming an interrupted session.
+
+**Standing Goal (optional):** For long autonomous, headless (`-p`), scheduled, or ultracode missions — where standing down too early is the failure mode — offer to set a Claude Code `/goal` that keeps the session from stopping until the mission is genuinely complete. Compose it from the sailing orders rather than by hand:
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py goal-condition \
+  --mission-dir {mission-dir} --record
+```
+
+Present the printed `/goal ...` line for the user to set. If the user already set a `/goal` before invoking Nelson, do NOT replace it — read it back with a bare `/goal`, reconcile the sailing orders to it, and only re-issue a composed goal with the user's agreement. Skip this for short interactive missions where the human is steering turn by turn. You MUST read `references/goal-alignment.md` before setting a goal — the evaluator judges the condition against the conversation transcript only, so completion evidence must be surfaced into chat (this shapes Stand Down in Step 8).
 
 **The Estimate opt-in:** Before proceeding, ask the user:
 
@@ -352,6 +361,8 @@ Reference `references/admiralty-templates/captains-log.md` for the captain's log
 **Session State Cleanup:** Remove the session state file by deleting `.nelson/.active-{SESSION_ID}`.
 
 **Mission Complete Gate:** You MUST NOT declare the mission complete until `{mission-dir}/captains-log.md` exists on disk and has been confirmed readable. If context pressure is high, write a minimal log noting which sections were abbreviated — but the file must exist. Skipping Step 8 is never permitted.
+
+**Clear the Standing Goal:** If a `/goal` is active, its evaluator only sees this conversation — so state the completion evidence in chat for the goal to auto-clear: the success metric result (matching the sailing orders' metric), that `captains-log.md` was written (with its path), and that stand-down was recorded. Do NOT tell the user to run `/goal clear` on a successful mission — the goal clears itself once this evidence is visible. Only if the mission was abandoned: run `scuttle-and-reform`, state the blocking reason in chat, and log a `goal_cleared` event via `nelson-data.py event`. See `references/goal-alignment.md`.
 
 **GitHub Star Prompt (one-time, success only):** After the Mission Complete Gate passes, ask the user once whether they would like to star the Nelson repo (canonical slug `harrymunro/nelson`). Run all three preflight checks below; if any prints `SKIP`, skip the prompt silently and finish Stand Down.
 

--- a/skills/nelson/references/admiralty-templates/battle-plan.md
+++ b/skills/nelson/references/admiralty-templates/battle-plan.md
@@ -8,6 +8,18 @@ Every captain's brief opens with the commander's intent from the Estimate (§2) 
 Commander's intent:
 [One paragraph from the Estimate §2 — prepended to every captain's brief.]
 
+Workflow suitability:
+[For non-workflow modes: one line explaining why workflow was not selected.]
+
+Workflow Charter: [include only when mode is workflow or hybrid-workflow]
+- Execution primitive: [workflow | hybrid-workflow]
+- Suitability: [why scripted orchestration is appropriate]
+- Phases: [probe/full run/stage names and purposes]
+- Human gates: [approval required before/after stages]
+- Verification contract: [how findings or edits become accepted]
+- Cost guardrail: [probe, scope cap, token/time limit, stop trigger]
+- Fallback mode: [agent-team | single-session]
+
 Task ID:
 - Name:
 - Owner: [assigned at Step 4 — Form the Squadron]
@@ -34,6 +46,8 @@ Task ID:
 **Acceptance criteria inheritance.** Each task inherits the acceptance criteria of its parent effect from the Estimate (§3). Captains own the choice of verification method per criterion (test, type-check, lint, review, or visual). The quarterdeck records each outcome (`pass` / `fail` / `not-verified`) via `nelson-data.py estimate-outcome`.
 
 JSON schema note: the battle-plan `task` object accepts an optional `acceptance_criteria: list[str]` field carrying the inherited criteria. This enables programmatic aggregation of verification outcomes. The `task` object also accepts an optional `modification_targets: list[str]` field for tracking the functions, environment variables, or configuration that must be modified in place.
+
+**Workflow advisory fields.** The top-level battle-plan object may include optional planning fields: `execution_primitive`, `workflow_suitability`, `workflow_phases`, `human_gates`, `verification_contract`, `cost_guardrail`, `fallback_mode`, and `workflow`. These are advisory in v1. They document the workflow charter and gates; they do not generate runnable `.claude/workflows/*.js` files.
 
 **`admiralty-action-required`:** Mark `yes` for any task where a step cannot be completed by an agent — requires the human to interact with an external system, provide credentials or URLs, or take an action only the human can perform. Fill this field consciously for every task; leaving it blank is a claim that the task requires no human action. When marked `yes`, the admiral will surface this in the Admiralty Action List before agents launch, and the captain will invoke the `awaiting-admiralty` standing order when the step is reached.
 

--- a/skills/nelson/references/admiralty-templates/crew-briefing.md
+++ b/skills/nelson/references/admiralty-templates/crew-briefing.md
@@ -29,7 +29,7 @@ Standing Orders:
   variables that duplicate existing ones. If you believe a rewrite is necessary,
   signal the admiral with your rationale before proceeding.
 - Report blockers to admiral immediately with options and one recommendation
-- Execution mode: [subagents | agent-team] — your available coordination tools are listed in references/tool-mapping.md
+- Execution mode: [single-session | subagents | agent-team | workflow | hybrid-workflow] — your available coordination tools are listed in references/tool-mapping.md
 - When done, report: deliverable, validation evidence, failure modes, rollback note
 - File a damage report to {mission-dir}/damage-reports/{ship-name}.json when your task
   is complete or when hull integrity crosses a threshold (Green → Amber → Red → Critical).

--- a/skills/nelson/references/goal-alignment.md
+++ b/skills/nelson/references/goal-alignment.md
@@ -1,0 +1,141 @@
+# Goal Alignment
+
+Nelson treats a Claude Code `/goal` as the admiral's **standing goal**: a
+harness-level completion barrier that keeps a session from standing down before
+the mission is truly done. Where Nelson's Mission Complete Gate is a discipline
+the admiral applies to itself, the standing goal is enforced by the harness — it
+fires after every turn and blocks stopping until a condition is judged met.
+
+## What a `/goal` is
+
+`/goal <condition>` installs a **session-scoped Stop hook**. After each turn a
+small, fast evaluator model judges whether the natural-language condition holds
+and either lets the session stop or sends it back to keep working. The goal
+**auto-clears** once the condition is judged met. There is **one goal per
+session**; setting a new one replaces the old. Clear early with `/goal clear`
+(aliases: `stop`, `off`, `reset`, `none`, `cancel`); check status with a bare
+`/goal`. A condition may carry its own bound, e.g. `... or stop after 20 turns`.
+
+Requires Claude Code v2.1.139+. Unavailable when `disableAllHooks` or
+`allowManagedHooksOnly` is set — in that case rely on the Mission Complete Gate
+alone.
+
+## The transcript rule (read this first)
+
+**The evaluator judges the condition against the conversation transcript only.
+It does not read files or run commands.** Nelson's completion evidence —
+`captains-log.md`, `stand-down.json` — lives on disk, which the evaluator cannot
+see. So a well-formed Nelson goal must be phrased against facts the admiral
+**surfaces into the conversation**, and Stand Down must actually state them.
+
+If the goal is phrased against on-disk artifacts the admiral never mentions in
+chat, the Stop hook will loop forever on a mission that is genuinely complete.
+This is the single most common way to misuse `/goal` with Nelson.
+
+## Composing the condition
+
+Do not hand-write the condition. Compose it from the sailing orders so it stays
+aligned with `outcome`, `success_metric`, and `stop_criteria`:
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py goal-condition \
+  --mission-dir {mission-dir} --record
+```
+
+This prints a ready-to-paste `/goal ...` line and (with `--record`) persists the
+condition into `sailing-orders.json` and logs a `goal_set` event so a resumed
+session can re-establish it. The composed condition requires, in the transcript:
+the success metric confirmed met, every stop criterion satisfied, and the
+captain's log written with its path stated — plus a legitimate stop path if the
+mission is formally abandoned via `scuttle-and-reform`. Add `--max-turns N` for a
+turn cap, `--json` for a machine-readable object. See `references/structured-data.md`.
+
+## When to set a standing goal
+
+Set one when the session must run to completion without a human watching every
+turn:
+
+- long autonomous missions where premature stand-down is the failure mode;
+- headless / `-p` invocations and scheduled runs;
+- ultracode or otherwise high-automation sessions;
+- any mission where "don't stop until the log is written" is worth enforcing.
+
+Prefer **not** to set one for short, interactive missions where the human is
+steering turn by turn — the Stop hook mostly adds friction there, and the
+Mission Complete Gate already covers you.
+
+If the user set a `/goal` **before** invoking Nelson, do not silently replace it.
+Read it back with a bare `/goal`, reconcile the sailing orders to it (the goal is
+the outer contract; the sailing orders must serve it), and only re-issue a
+composed goal if the user agrees.
+
+## Relationship to the Mission Complete Gate
+
+The two are complementary, not redundant:
+
+- **Mission Complete Gate** (Step 8) is Nelson's internal rule: never declare
+  complete until `captains-log.md` exists on disk. It is what the admiral
+  checks.
+- **Standing goal** is the harness backstop: the session physically cannot stop
+  until the transcript shows the mission is done.
+
+Keep them in agreement. The composed condition already mirrors the gate, so at
+Stand Down, satisfying the gate (and *stating* it in chat) is what clears the
+goal. If you ever tighten the gate, re-compose the goal so the two do not drift.
+
+## Clearing at Stand Down
+
+When Stand Down completes, state the completion evidence in the conversation so
+the evaluator can clear the goal:
+
+- the success metric result (matching `success_metric`);
+- that `captains-log.md` was written, with its path;
+- that stand-down was recorded.
+
+The goal then auto-clears. Do **not** instruct the user to run `/goal clear` on a
+successful mission — that is only for abandoning a goal early. If the mission is
+abandoned, run `scuttle-and-reform`, state the blocking reason in chat (which the
+condition accepts as a legitimate stop), and log a `goal_cleared` event.
+
+## Session resumption
+
+A goal active at session end is **restored on `--resume` / `--continue`** (the
+condition carries over; the turn/time/token counters reset). It is **not**
+restored in a fresh, non-resumed session, and never crosses into a brand-new
+session. So on resumption of an underway mission, check whether a goal is active
+(bare `/goal`); if none is and `sailing-orders.json` carries a recorded
+`goal_condition`, re-issue it. This is part of the session-resumption procedure —
+see `references/damage-control/session-resumption.md`.
+
+## Subagents
+
+Whether a parent goal governs spawned captains/marines is **undocumented**. Do
+not depend on it. Nelson's model already fits the safe assumption: the standing
+goal governs the **admiral's** session — the one that stands down — while
+captains and marines are governed by Nelson's own gates (action stations,
+task-completion quality, red-cell review). Never rely on a `/goal` to police
+subagent completion; use the battle plan's verification contract for that.
+
+## Interaction with workflows
+
+A standing goal survives a resumed session, but a dynamic workflow run has **no
+mid-run human gate** and the goal evaluator does not see inside it. Use the goal
+as the mission-level completion barrier around workflow stages, not as a control
+inside a run. For `hybrid-workflow`, the goal should require that every planned
+stage's results have been reviewed and accepted in the transcript before the
+session may stop. See `references/workflow-doctrine.md`.
+
+## Anti-patterns
+
+- **Unverifiable goal:** a condition phrased against on-disk state the admiral
+  never states in chat. The Stop hook loops forever. Compose from sailing orders
+  instead.
+- **Goal that fights the permission gate:** a condition worded so the session
+  cannot stop while it is legitimately waiting for user approval (Step 5) or an
+  admiralty action. Word completion as the target; let the escape path cover
+  blocked-on-human states, or set a turn bound.
+- **Replacing a user's goal silently:** clobbering a `/goal` the user set before
+  invoking Nelson. Reconcile, don't overwrite.
+- **Goal instead of the gate:** treating `/goal` as a substitute for writing the
+  captain's log. The goal enforces the gate; it does not replace the work the
+  gate protects.

--- a/skills/nelson/references/squadron-composition.md
+++ b/skills/nelson/references/squadron-composition.md
@@ -6,11 +6,13 @@ Use this file to choose execution mode and team size.
 
 **User preference override:** If the user explicitly requests a specific execution mode (e.g., "use agent teams"), that request MUST be honoured. User preference takes priority over the decision matrix below. Do not second-guess or override the user's choice.
 
-Evaluate all three conditions and select the best fit. When two modes could apply, prefer the one that gives captains more autonomy.
+Evaluate all five conditions and select the best fit. When two modes could apply, prefer the one that gives captains more autonomy while preserving required human gates.
 
 - `single-session`: Work is sequential, tightly coupled, or mostly in the same files.
 - `subagents`: Work is parallel and each captain's task is fully independent — no shared coordination surface needed.
 - `agent-team`: Work is parallel and captains benefit from a shared task list, peer messaging, or coordinated deliverables. Also use when 4+ captains are needed, or when the user requests it.
+- `workflow`: Work is a single approved dynamic workflow run with large fan-out, repeatable review or migration logic, codebase-wide audit scope, or cross-checked research. Treat the workflow as one fleet asset, not as ordinary captains.
+- `hybrid-workflow`: Work is a Nelson-gated sequence of workflow stages. Use when a probe, Station 2/3 sign-off, or human approval is required between workflow runs.
 
 ## Decision Matrix
 
@@ -21,7 +23,11 @@ Evaluate all three conditions and select the best fit. When two modes could appl
 | Parallel implementation with dependencies | `agent-team` | Supports teammate-to-teammate coordination |
 | 4+ parallel captains | `agent-team` | Shared task list simplifies coordination at scale |
 | High threat or high blast radius | `agent-team` + red-cell navigator | Adds explicit control points |
+| Large repeatable audit, migration, or research fan-out | `workflow` | Dynamic workflow scripts can orchestrate many agents and aggregate results |
+| Workflow-suitable mission with stage gates or Station 2/3 approvals | `hybrid-workflow` | Human approval happens between separate workflow runs |
 | User explicitly requests a mode | As requested | User preference overrides the matrix |
+
+Before selecting `workflow` or `hybrid-workflow`, read `workflow-doctrine.md` and record the workflow suitability, probe, verification contract, cost guardrail, and fallback mode in the battle plan. Nelson v1 produces a workflow charter; it does not directly generate or launch `.claude/workflows/*.js`.
 
 ## Team Sizing
 

--- a/skills/nelson/references/structured-data.md
+++ b/skills/nelson/references/structured-data.md
@@ -4,6 +4,8 @@ Reference for the `nelson-data.py` script. Run these commands via Bash at each w
 
 The script lives at `scripts/nelson-data.py` relative to the skill directory. All subcommands handle schema validation, timestamps, and file I/O. Only stdout is consumed — the script source is never loaded into context.
 
+Mode enum: `single-session | subagents | agent-team | workflow | hybrid-workflow`.
+
 ## Script Commands
 
 ### `init` — Create mission and sailing orders
@@ -38,7 +40,7 @@ python3 .claude/skills/nelson/scripts/nelson-data.py squadron \
   --mode agent-team
 ```
 
-Repeat `--captain "name:class:model:task_id"` for each captain. Fields are colon-delimited.
+Repeat `--captain "name:class:model:task_id"` for each captain. Fields are colon-delimited. Valid modes are `single-session`, `subagents`, `agent-team`, `workflow`, and `hybrid-workflow`.
 
 ### `task` — Add task to battle plan
 
@@ -80,6 +82,19 @@ python3 .claude/skills/nelson/scripts/nelson-data.py event \
   --checkpoint 2 \
   --task-id 1 --task-name "Auth module refactor" --owner "HMS Argyll" \
   --station-tier 1 --verification passed
+```
+
+Workflow telemetry uses the same loose key-value mechanism. Nelson v1 allows manual entry from Claude Code's `/workflows` view; do not require telemetry fields that are not programmatically exposed.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py event \
+  --mission-dir .nelson/missions/2026-03-27_120000_a1b2c3d4 \
+  --type workflow_probe_completed \
+  --workflow-name "auth-audit" --phase probe --status completed \
+  --agents-total 8 --agents-completed 8 \
+  --tokens-used 42000 --elapsed-minutes 11 \
+  --summary "Probe found two real issues and three false positives" \
+  --next-gate "User approval before full run"
 ```
 
 ### `handoff` — Write a typed handoff packet
@@ -155,7 +170,7 @@ Repeat `--adopt` and `--avoid` for each pattern. These are optional — omitting
 
 Run at Step 3 instead of individual `task`, `squadron`, and `plan-approved` calls. Consolidates the entire formation phase into a single command.
 
-Reads a plan JSON file containing tasks and squadron definitions. Registers all tasks, records the squadron, computes DAG metrics, and runs the conflict scan. Outputs a structured JSON summary to stdout; progress messages go to stderr.
+Reads a plan JSON file containing tasks and squadron definitions. Registers all tasks, records the squadron, computes DAG metrics, and runs the conflict scan. Optional workflow charter and battle-plan advisory fields are preserved in `battle-plan.json`. Outputs a structured JSON summary to stdout; progress messages go to stderr.
 
 ```bash
 python3 .claude/skills/nelson/scripts/nelson-data.py form \
@@ -189,6 +204,37 @@ The plan JSON file must contain `squadron` and `tasks` keys:
   ]
 }
 ```
+
+For `workflow` or `hybrid-workflow`, add an optional `workflow` object. Existing plan JSON without this object remains valid.
+
+```json
+{
+  "mode": "hybrid-workflow",
+  "workflow": {
+    "suitability": "large fan-out across independent files",
+    "phases": [
+      {
+        "name": "probe",
+        "purpose": "Run a small representative slice",
+        "requires_human_gate_after": true
+      },
+      {
+        "name": "full_run",
+        "purpose": "Run the approved workflow across target scope",
+        "requires_human_gate_after": false
+      }
+    ],
+    "verification_contract": [
+      "Findings require independent reviewer confirmation",
+      "Rejected or uncertain findings must be surfaced separately"
+    ],
+    "cost_guardrail": "Run a small slice before full repo scope",
+    "fallback_mode": "agent-team"
+  }
+}
+```
+
+Top-level advisory fields are also preserved when present: `execution_primitive`, `workflow_suitability`, `workflow_phases`, `human_gates`, `verification_contract`, `cost_guardrail`, and `fallback_mode`.
 
 Output summary (stdout):
 
@@ -438,6 +484,7 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py set \
 | Step 4: Get Permission to Sail | (none) | — | (conversation-only) |
 | Step 5: Each Checkpoint | `checkpoint` | `mission-log.json`, `fleet-status.json` | `quarterdeck-report.md` |
 | Step 5: Between Checkpoints | `event` | `mission-log.json` | -- |
+| Step 5: Workflow stage boundary | `event --type workflow_*` | `mission-log.json` | workflow telemetry from `/workflows` view |
 | Step 5: Relief on Station | `handoff` | `mission-log.json`, `turnover-briefs/{ship}.json` | `turnover-briefs/{ship}.md` (optional companion) |
 | Step 5: Action Stations | `event --type task_completed` | `mission-log.json` | -- |
 | Step 6: Stand Down | `stand-down` | `mission-log.json`, `fleet-status.json`, `stand-down.json`, `.nelson/memory/patterns.json`, `.nelson/memory/standing-order-stats.json` | `captains-log.md` |
@@ -467,6 +514,11 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py set \
 | `phase_override` | Manual phase set (recovery) | from_phase, to_phase |
 | `permission_granted` | User approves formation | (empty data) |
 | `mission_complete` | Step 6 | outcome_achieved, tasks_completed, total_tokens_consumed, duration_minutes |
+| `workflow_charter_created` | Workflow charter approved | workflow_name, phase, summary, next_gate |
+| `workflow_probe_completed` | Sounding-the-Channel probe complete | workflow_name, phase, status, agents_total, agents_completed, tokens_used, elapsed_minutes, summary, next_gate |
+| `workflow_run_started` | Workflow stage launched | workflow_name, phase, status, agents_total, summary |
+| `workflow_run_completed` | Workflow stage completed | workflow_name, phase, status, agents_total, agents_completed, tokens_used, elapsed_minutes, summary, next_gate |
+| `workflow_run_stopped` | Workflow stage halted | workflow_name, phase, status, agents_total, agents_completed, tokens_used, elapsed_minutes, summary, next_gate |
 
 ## JSON Schemas
 
@@ -539,6 +591,19 @@ All artifacts are stored in `{mission-dir}/`.
       "unblocks": "Task 3: Database migration"
     }
   ],
+  "workflow": {
+    "suitability": "large fan-out across independent files",
+    "phases": [
+      {
+        "name": "probe",
+        "purpose": "Run a small representative slice",
+        "requires_human_gate_after": true
+      }
+    ],
+    "verification_contract": ["Findings require independent reviewer confirmation"],
+    "cost_guardrail": "Run a small slice before full repo scope",
+    "fallback_mode": "agent-team"
+  },
   "created_at": "2026-03-27T12:05:00Z",
   "amended_at": null
 }

--- a/skills/nelson/references/structured-data.md
+++ b/skills/nelson/references/structured-data.md
@@ -24,6 +24,25 @@ python3 .claude/skills/nelson/scripts/nelson-data.py init \
 
 Optional: pass `--session-id <8-hex>` to use a specific session identifier (e.g., for deterministic tests or when resuming with a known id). Must be exactly 8 lowercase hex characters; invalid values are rejected.
 
+### `goal-condition` — Compose a Claude Code `/goal` condition (read-only unless `--record`)
+
+Run at Step 1, after `init`, when the mission warrants a standing goal (long autonomous, headless, scheduled, or ultracode runs). Reads `sailing-orders.json` and composes a transcript-verifiable `/goal` condition from `outcome`, `success_metric`, and `stop_criteria`. Prints a ready-to-paste `/goal ...` line to stdout.
+
+```bash
+python3 .claude/skills/nelson/scripts/nelson-data.py goal-condition \
+  --mission-dir .nelson/missions/2026-03-27_120000_a1b2c3d4 \
+  --max-turns 40 --record
+```
+
+Arguments:
+
+- `--mission-dir` (required) — mission directory containing `sailing-orders.json`.
+- `--max-turns N` — append `or stop after N turns` as a safety bound.
+- `--record` — persist the composed condition into `sailing-orders.json` as `goal_condition` and log a `goal_set` event (so a resumed session can re-establish the goal). Without `--record` the command is read-only.
+- `--json` — emit `{condition, command, char_count, within_limit, recorded}` instead of the plain `/goal` line.
+
+The composed condition is worded against facts visible in the conversation (metric confirmed, stop criteria met, captain's log written with its path stated, stand-down recorded) because the `/goal` evaluator judges only the transcript. It also accepts a formal `scuttle-and-reform` abandonment as a legitimate stop. If the condition exceeds the 4,000-character `/goal` limit, a warning is printed to stderr and `within_limit` is `false`. See `references/goal-alignment.md` for the full doctrine.
+
 ### `squadron` — Record squadron formation
 
 Run at Step 3 after the squadron is formed.
@@ -478,6 +497,7 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py set \
 | Workflow Step | Script Command | JSON Written | Prose (existing) |
 |---|---|---|---|
 | Step 1: Sailing Orders | `init` | `sailing-orders.json`, `mission-log.json` | (conversation-only) |
+| Step 1: Standing Goal (optional) | `goal-condition --record` | `sailing-orders.json`, `mission-log.json` | `/goal` set in the session |
 | Step 2: Battle Plan | (none — owners not yet assigned) | — | (conversation-only) |
 | Step 3: Form Squadron | `form` (recommended), or individual `task` + `plan-approved` + `squadron` | `battle-plan.json`, `mission-log.json`, `fleet-status.json` | (conversation-only) |
 | Step 1-3: Headless | `headless` (CI/CD) | all of the above in one step | — |
@@ -519,6 +539,8 @@ python3 .claude/skills/nelson/scripts/nelson-phase.py set \
 | `workflow_run_started` | Workflow stage launched | workflow_name, phase, status, agents_total, summary |
 | `workflow_run_completed` | Workflow stage completed | workflow_name, phase, status, agents_total, agents_completed, tokens_used, elapsed_minutes, summary, next_gate |
 | `workflow_run_stopped` | Workflow stage halted | workflow_name, phase, status, agents_total, agents_completed, tokens_used, elapsed_minutes, summary, next_gate |
+| `goal_set` | Standing goal composed with `--record` | goal_condition |
+| `goal_cleared` | Standing goal cleared (mission abandoned) | reason |
 
 ## JSON Schemas
 
@@ -540,9 +562,12 @@ All artifacts are stored in `{mission-dir}/`.
   "out_of_scope": ["Migration script for existing sessions"],
   "stop_criteria": ["All tests pass", "No regressions in integration suite"],
   "handoff_artifacts": ["Updated auth module", "Test results"],
+  "goal_condition": "The Nelson mission is complete: ... (optional; present only when goal-condition --record was run)",
   "created_at": "2026-03-27T12:00:00Z"
 }
 ```
+
+`goal_condition` is optional and additive — it is written only by `goal-condition --record` and preserved through subsequent sailing-orders writes. A resumed session reads it to re-establish the standing goal.
 
 ### battle-plan.json (Write-Once, Amendable)
 

--- a/skills/nelson/references/tool-mapping.md
+++ b/skills/nelson/references/tool-mapping.md
@@ -9,6 +9,9 @@ Maps Nelson operations to Claude Code tool calls by execution mode.
 | Form the squadron | `TeamCreate` | agent-team |
 | Spawn captain | `Agent` with `team_name` + `name` | agent-team |
 | Spawn captain | `Agent` with `subagent_type` | subagents |
+| Charter dynamic workflow | Battle-plan Workflow Charter prompt | workflow / hybrid-workflow |
+| Launch workflow stage | Claude Code workflow run from approved charter | workflow / hybrid-workflow |
+| Record workflow telemetry | `nelson-data.py event --type workflow_* ...` | workflow / hybrid-workflow |
 | Create task (coordination) | `TaskCreate` | agent-team |
 | Assign task to captain | `TaskUpdate` with `owner` | agent-team |
 | Check task progress (coordination) | `TaskList` / `TaskGet` | agent-team |
@@ -45,11 +48,39 @@ Maps Nelson operations to Claude Code tool calls by execution mode.
     - **Available:** `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet` (for
       visibility tracking) ¹
     - **Not available:** `Agent`, `TeamCreate`, `TeamDelete`, `SendMessage`
+- **`workflow` mode:** One approved autonomous dynamic workflow run. Nelson v1
+  does not directly call a workflow API or write runnable workflow scripts; it
+  produces the Workflow Charter and verification contract that Claude Code can
+  use to create or run the workflow. Track the workflow as a fleet asset and log
+  `workflow_charter_created`, `workflow_run_started`, and
+  `workflow_run_completed` / `workflow_run_stopped` events as appropriate.
+    - **Available:** Workflow Charter, Claude Code workflow run, loose telemetry
+      via `nelson-data.py event`
+    - **Not available:** Mid-run Nelson approval gates. Stop the run and use
+      `hybrid-workflow` when approval is needed before continuing.
+- **`hybrid-workflow` mode:** A sequence of separately approved workflow stages.
+  Use for Station 2/3 work, Sounding-the-Channel probes, or any mission that
+  needs human sign-off between stages. Each stage is its own workflow run with
+  Nelson review before the next stage launches.
+    - **Available:** Same workflow primitives as `workflow`, plus Nelson
+      permission gates between stages
+    - **Not available:** Arbitrary mid-run human input inside a workflow stage
 
 ¹ Visibility tracking uses the same task tools as agent-team coordination but
 serves a different purpose: making mission progress visible in the user's
 Ctrl+T task list. In `subagents` and `single-session` modes, only the admiral
 calls these tools; captains never see or interact with these task entries.
+
+## Dynamic Workflow Notes
+
+Agents spawned by Claude Code workflows run in `acceptEdits` mode and inherit
+the session tool allowlist. Shell, web, or MCP calls outside that
+allowlist may still prompt. Therefore, the workflow charter must state any
+expected tool needs up front and the admiral must not assume a workflow can
+bypass permission gates.
+
+Use `workflow-doctrine.md` for suitability, Sounding-the-Channel probes,
+verification contracts, cost guardrails, telemetry, and damage-control mapping.
 
 ## Anti-Patterns
 
@@ -63,3 +94,6 @@ Common mode-tool mismatches and their correct alternatives. See
 | `Agent` with `subagent_type` to spawn a captain in agent-team mode | Agent is not registered as a teammate | Use `Agent` with `team_name` + `name` |
 | `TeamCreate` in subagents mode | Creates an unnecessary team structure | Omit — spawn captains directly with `Agent` |
 | `TaskCreate` by captains in subagents mode | No shared task list exists for captains | Admiral tracks visibility via `TaskCreate`/`TaskUpdate` in its own session; captains report via `Agent` return value |
+| Treating a workflow stage as an agent-team squadron | Workflows are scripted runs, not peer-messaging teams | Track it as a fleet asset with a Workflow Charter and telemetry |
+| Expecting human input inside a workflow run | Dynamic workflows do not provide arbitrary mid-run Nelson gates | Use `hybrid-workflow` and require approval between separate workflow runs |
+| Assuming Nelson v1 invokes workflow APIs directly | v1 ships doctrine and charters, not a workflow compiler | Give Claude Code the approved charter/prompt to create or run the workflow |

--- a/skills/nelson/references/tool-mapping.md
+++ b/skills/nelson/references/tool-mapping.md
@@ -12,6 +12,9 @@ Maps Nelson operations to Claude Code tool calls by execution mode.
 | Charter dynamic workflow | Battle-plan Workflow Charter prompt | workflow / hybrid-workflow |
 | Launch workflow stage | Claude Code workflow run from approved charter | workflow / hybrid-workflow |
 | Record workflow telemetry | `nelson-data.py event --type workflow_* ...` | workflow / hybrid-workflow |
+| Compose a standing-goal condition | `nelson-data.py goal-condition --mission-dir ...` | all modes |
+| Set the standing goal | `/goal <condition>` (Stop hook) | all modes |
+| Check / clear the standing goal | `/goal` / `/goal clear` | all modes |
 | Create task (coordination) | `TaskCreate` | agent-team |
 | Assign task to captain | `TaskUpdate` with `owner` | agent-team |
 | Check task progress (coordination) | `TaskList` / `TaskGet` | agent-team |
@@ -79,8 +82,23 @@ allowlist may still prompt. Therefore, the workflow charter must state any
 expected tool needs up front and the admiral must not assume a workflow can
 bypass permission gates.
 
-Use `workflow-doctrine.md` for suitability, Sounding-the-Channel probes,
-verification contracts, cost guardrails, telemetry, and damage-control mapping.
+A reusable workflow can be saved as `.claude/workflows/<name>.js` (project) or
+`~/.claude/workflows/<name>.js` (personal) and re-run as the `/<name>` command;
+watch and pause/resume runs from the `/workflows` view. Nelson's charter is what
+you hand to that mechanism. See `workflow-doctrine.md` for the charter-to-script
+bridge, Sounding-the-Channel probes, verification contracts, cost guardrails,
+telemetry, and damage-control mapping.
+
+## Standing Goal Notes
+
+`/goal <condition>` is an admiral-level Stop hook, not a per-agent tool — set it
+once for the session, never inside a captain or workflow run. Its evaluator
+judges the condition against the **conversation transcript only**; it does not
+read files or run commands. Because Nelson's completion evidence lives on disk,
+compose the condition with `nelson-data.py goal-condition` (which words it
+against transcript-visible facts) rather than by hand, and surface that evidence
+into chat at Stand Down. Full doctrine — availability, resumption, subagent
+scope, anti-patterns — is in `references/goal-alignment.md`.
 
 ## Anti-Patterns
 
@@ -97,3 +115,5 @@ Common mode-tool mismatches and their correct alternatives. See
 | Treating a workflow stage as an agent-team squadron | Workflows are scripted runs, not peer-messaging teams | Track it as a fleet asset with a Workflow Charter and telemetry |
 | Expecting human input inside a workflow run | Dynamic workflows do not provide arbitrary mid-run Nelson gates | Use `hybrid-workflow` and require approval between separate workflow runs |
 | Assuming Nelson v1 invokes workflow APIs directly | v1 ships doctrine and charters, not a workflow compiler | Give Claude Code the approved charter/prompt to create or run the workflow |
+| Hand-writing a `/goal` against on-disk artifacts | The evaluator sees only the transcript, so it never observes them and the Stop hook loops forever | Compose with `nelson-data.py goal-condition` and state completion evidence in chat |
+| Setting a `/goal` inside a captain or workflow run | The goal is a session-scoped admiral backstop, not a per-agent control | Set it once at Step 1; govern subagents with the verification contract |

--- a/skills/nelson/references/workflow-doctrine.md
+++ b/skills/nelson/references/workflow-doctrine.md
@@ -4,7 +4,9 @@ Nelson treats Claude Code dynamic workflows as a fleet asset: powerful for broad
 
 ## What a workflow is
 
-A dynamic workflow moves orchestration into a JavaScript workflow script. The script can fan work out to many agents, keep intermediate results in script variables, aggregate outputs, and repeat a review or migration pattern across a large scope. Nelson v1 does **not** compile or invoke workflow scripts directly; it produces the doctrine, battle-plan charter, gates, and verification contract that Claude Code can use to create or run the workflow.
+A dynamic workflow moves orchestration into a JavaScript workflow script. The script can fan work out to many agents, keep intermediate results in script variables, aggregate outputs, and repeat a review or migration pattern across a large scope. The script begins with `export const meta = {...}` and a body using `agent()`, `parallel()`, `pipeline()`, and `phase()` under top-level `await`. A workflow may be one-shot (Claude writes and runs it inline) or saved as `.claude/workflows/<name>.js` (project) or `~/.claude/workflows/<name>.js` (personal) and re-run as the `/<name>` command; runs are watched, paused, and resumed from the `/workflows` view.
+
+Nelson v1 does **not** compile or invoke workflow scripts directly; it produces the doctrine, battle-plan charter, gates, and verification contract that Claude Code can use to create or run the workflow. The charter-to-script bridge below turns that charter into a script skeleton a power user can run without re-deriving the structure.
 
 `ultracode` is not a Nelson execution mode. It is a Claude Code `xhigh` effort/automation setting that can let Claude decide when dynamic workflows are appropriate. Nelson still owns the charter, approval gate, risk tiering, and acceptance criteria.
 
@@ -70,6 +72,47 @@ When selecting `workflow` or `hybrid-workflow`, include a compact Workflow Chart
 - `cost_guardrail`: budget limits, scope limits, and stop triggers;
 - `fallback_mode`: usually `agent-team`, or `single-session` for tightly coupled recovery.
 
+## From charter to a runnable script
+
+The charter is not just documentation — its fields map one-to-one onto a Workflow
+script, so a power user can run the approved plan instead of re-deriving it. This
+is a **starting skeleton** the admiral hands over after approval, not something
+Nelson executes itself. Each charter field becomes a script element:
+
+- `workflow_phases` → a `phase('...')` group, or a `pipeline`/`parallel` stage per phase;
+- `verification_contract` → a verify stage that adversarially re-checks each finding and drops those that fail the contract;
+- `cost_guardrail` → a Sounding-the-Channel probe first, plus a budget/agent-count guard before the full run;
+- `human_gates` → for `hybrid-workflow`, a script boundary where the run ends and the next stage is a separate approved run (workflows have no mid-run gate);
+- `fallback_mode` → the mode to drop to if the probe shows low signal.
+
+A review-shaped charter maps to the canonical find-then-verify pipeline:
+
+```javascript
+export const meta = {
+  name: 'audit-<scope>',            // from the charter's workflow name
+  description: '<workflow_suitability>',
+  phases: [{ title: 'Probe' }, { title: 'Review' }, { title: 'Verify' }],
+}
+// Sounding the Channel — cost_guardrail: prove signal on one slice first.
+const probe = await agent(`Review ${args.slice} for <finding type>.`, { phase: 'Probe', schema: FINDINGS })
+if (!probe.findings.length) return { stopped: 'probe found no signal; fall back to <fallback_mode>' }
+
+// Full run — one reviewer per target, each finding verified as its review lands.
+const results = await pipeline(
+  args.targets,                                    // bounded per cost_guardrail
+  t => agent(`Review ${t} for <finding type>.`, { phase: 'Review', schema: FINDINGS }),
+  review => parallel(review.findings.map(f => () =>  // verification_contract
+    agent(`Adversarially verify: ${f.summary}. Default to rejected if uncertain.`, { phase: 'Verify', schema: VERDICT })
+      .then(v => ({ ...f, verdict: v })))),
+)
+return { confirmed: results.flat().filter(Boolean).filter(f => f.verdict?.real) }
+```
+
+Keep the charter's Station tier in view: Station 2 outputs still need red-cell
+review and Station 3 outputs still need explicit human confirmation, so a
+Station 2/3 audit runs as `hybrid-workflow` — end the run at each `human_gate`
+and resume only after approval.
+
 ## Verification contract
 
 Workflow output is not accepted merely because the workflow completed. The battle plan must say what counts as verified. Common contracts:
@@ -108,6 +151,23 @@ At each checkpoint or workflow stage boundary, capture what Claude Code exposes 
 - next gate.
 
 Nelson v1 mission-log events are deliberately loose: `workflow_name`, `phase`, `status`, `agents_total`, `agents_completed`, `tokens_used`, `elapsed_minutes`, `summary`, and `next_gate` are all acceptable event data fields.
+
+## Standing goal and workflows
+
+A Claude Code `/goal` and a workflow operate at different levels and do not
+interfere, but they must be coordinated:
+
+- The goal is the **mission-level** completion barrier; the workflow is an
+  orchestration primitive inside the mission. Never set a `/goal` inside a
+  workflow run — set it once at Step 1 (see `references/goal-alignment.md`).
+- The goal evaluator does not see inside a run, and a run has no mid-run human
+  gate. So the goal cannot police workflow internals — it enforces that the
+  mission's results are reviewed and accepted in the transcript before the
+  session may stop.
+- For `hybrid-workflow`, word the goal so it is met only once every planned stage
+  has completed and its results have been accepted in the conversation. That
+  keeps the session from standing down between stages while the human gate is
+  still pending.
 
 ## Damage-control mapping
 

--- a/skills/nelson/references/workflow-doctrine.md
+++ b/skills/nelson/references/workflow-doctrine.md
@@ -1,0 +1,119 @@
+# Workflow Doctrine
+
+Nelson treats Claude Code dynamic workflows as a fleet asset: powerful for broad, repeatable orchestration, but still governed by sailing orders, action-station risk controls, cost discipline, and explicit verification.
+
+## What a workflow is
+
+A dynamic workflow moves orchestration into a JavaScript workflow script. The script can fan work out to many agents, keep intermediate results in script variables, aggregate outputs, and repeat a review or migration pattern across a large scope. Nelson v1 does **not** compile or invoke workflow scripts directly; it produces the doctrine, battle-plan charter, gates, and verification contract that Claude Code can use to create or run the workflow.
+
+`ultracode` is not a Nelson execution mode. It is a Claude Code `xhigh` effort/automation setting that can let Claude decide when dynamic workflows are appropriate. Nelson still owns the charter, approval gate, risk tiering, and acceptance criteria.
+
+## Ultracode readiness
+
+Before using ultracode on a Nelson mission, make sure the mission is safe for autonomous workflow selection:
+
+- sailing orders state outcome, metric, deadline, forbidden actions, and budget;
+- file ownership or target scope is bounded enough for broad fan-out;
+- Station 2/3 gates are written as stage boundaries, not hoped-for mid-run prompts;
+- verification contract says how accepted, rejected, and uncertain outputs are handled;
+- fallback mode is named before launch.
+
+If any of these are missing, do the planning work first and use `hybrid-workflow` or a conventional `agent-team` instead of letting ultracode choose blindly.
+
+## Execution modes
+
+- `workflow`: one approved autonomous workflow run for large fan-out, repeatable review, broad migration, audit, or cross-checked research.
+- `hybrid-workflow`: a Nelson-gated sequence of separate workflow stages. Use this when the mission needs human review between stages, staged risk controls, or Station 2/3 approvals.
+
+Station 2/3 work should prefer `hybrid-workflow`. Workflows do not support arbitrary mid-run human input; handle sign-off between stages by ending one workflow run, presenting results, and launching the next run only after approval.
+
+## Suitability checks
+
+Choose a workflow only when the work benefits from scripted orchestration. Good fits:
+
+- codebase-wide audits across many files, packages, or services;
+- large migrations with the same transformation repeated across independent targets;
+- cross-checked research or review where multiple agents independently inspect the same question;
+- repeatable verification sweeps with clear acceptance criteria;
+- broad issue triage where findings can be collected, ranked, and de-duplicated.
+
+Prefer `agent-team`, `subagents`, or `single-session` instead when:
+
+- the work is tightly coupled in the same files;
+- the path depends on frequent human steering;
+- the mission needs rich peer-to-peer negotiation among a small number of captains;
+- expected cost exceeds value or the scope cannot be bounded;
+- acceptance criteria are vague enough that a workflow would amplify ambiguity.
+
+## Sounding the Channel
+
+Before full scope, run a small representative probe: one package, a handful of files, one migration pattern, or one research slice. The probe must report:
+
+- target slice and why it represents the wider channel;
+- agents completed versus total;
+- elapsed time and approximate token burn;
+- accepted findings, rejected findings, and uncertain findings;
+- verification evidence for any accepted output;
+- changes needed to the charter before broad execution.
+
+Do not proceed from probe to full run until the admiral has reviewed the probe and, for `hybrid-workflow`, the user has explicitly approved the next stage.
+
+## Workflow charter fields
+
+When selecting `workflow` or `hybrid-workflow`, include a compact Workflow Charter in `battle-plan.md` and preserve the same data in `battle-plan.json` where useful:
+
+- `execution_primitive`: `workflow` or `hybrid-workflow`;
+- `workflow_suitability`: why a workflow is appropriate;
+- `workflow_phases`: planned stages, including probes and full runs;
+- `human_gates`: approvals required before or after stages;
+- `verification_contract`: how findings or edits become accepted;
+- `cost_guardrail`: budget limits, scope limits, and stop triggers;
+- `fallback_mode`: usually `agent-team`, or `single-session` for tightly coupled recovery.
+
+## Verification contract
+
+Workflow output is not accepted merely because the workflow completed. The battle plan must say what counts as verified. Common contracts:
+
+- independent reviewer confirmation for findings above a risk threshold;
+- tests, lint, type checks, or targeted manual review for generated edits;
+- red-cell review for Station 2+ outputs;
+- rejected and uncertain findings surfaced separately, not hidden in the summary;
+- sample-based audit of accepted findings before final synthesis;
+- rollback notes for any edit-bearing result.
+
+Action Stations still apply. Station 2 requires adversarial review; Station 3 requires explicit human confirmation and contingency planning.
+
+## Cost controls
+
+Workflows can spend substantially more tokens than ordinary delegation because they may create many agents and hold intermediate results in script state. Apply these controls:
+
+- run Sounding the Channel before broad execution;
+- cap target scope per phase;
+- cap agent count per wave where possible;
+- stop after repeated agent failures rather than retrying blindly;
+- require approximate token burn in telemetry;
+- narrow or fall back if the probe shows low signal, high duplicate findings, or excessive cost.
+
+## Telemetry
+
+At each checkpoint or workflow stage boundary, capture what Claude Code exposes and allow manual entry from the `/workflows` view. Useful fields:
+
+- workflow name and phase;
+- agents completed / total;
+- failed agents;
+- elapsed time;
+- token burn or best available estimate;
+- accepted, rejected, and uncertain findings;
+- current status;
+- next gate.
+
+Nelson v1 mission-log events are deliberately loose: `workflow_name`, `phase`, `status`, `agents_total`, `agents_completed`, `tokens_used`, `elapsed_minutes`, `summary`, and `next_gate` are all acceptable event data fields.
+
+## Damage-control mapping
+
+- **Low signal after probe:** stop, narrow the charter, or fall back to `agent-team`.
+- **Budget burn too high:** halt at the next stage boundary, reduce scope, and record the cost finding.
+- **Agent failures cluster around one target:** isolate that target for a human-reviewed or `single-session` task.
+- **Contradictory findings:** require independent reviewer confirmation before acceptance.
+- **Station 2/3 gate needed:** stop the current run and resume only as a separate approved `hybrid-workflow` stage.
+- **Workflow runner or tool allowlist problem:** do not improvise around prompts; surface the blocked call and revise the charter or allowlist.

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -30,6 +30,7 @@ import sys
 
 from nelson_data_calibration import cmd_trust_report
 from nelson_data_fleet import VALID_METRICS, cmd_analytics, cmd_brief, cmd_history, cmd_index
+from nelson_data_goal import cmd_goal_condition
 from nelson_data_lifecycle import (
     cmd_admiralty_decision,
     cmd_checkpoint,
@@ -148,6 +149,30 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915 -- argparse subc
     # --- plan-approved ---
     p_pa = subs.add_parser("plan-approved", help="Finalize battle plan")
     p_pa.add_argument("--mission-dir", required=True, help="Mission directory path")
+
+    # --- goal-condition ---
+    p_goal = subs.add_parser(
+        "goal-condition",
+        help="Compose a Claude Code /goal condition from sailing orders",
+    )
+    p_goal.add_argument("--mission-dir", required=True, help="Mission directory path")
+    p_goal.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        help="Optional turn cap appended as 'or stop after N turns'",
+    )
+    p_goal.add_argument(
+        "--record",
+        action="store_true",
+        help="Persist the condition into sailing-orders.json and log a goal_set event",
+    )
+    p_goal.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Emit a JSON object (condition, command, char_count, within_limit)",
+    )
 
     # --- skip-estimate ---
     p_se = subs.add_parser("skip-estimate", help="Record that the ESTIMATE phase is being skipped")
@@ -501,6 +526,7 @@ def main() -> None:
         "init": lambda: cmd_init(args),
         "squadron": lambda: cmd_squadron(args),
         "task": lambda: cmd_task(args),
+        "goal-condition": lambda: cmd_goal_condition(args),
         "plan-approved": lambda: cmd_plan_approved(args),
         "skip-estimate": lambda: cmd_skip_estimate(args),
         "estimate-outcome": lambda: cmd_record_estimate_outcome(args),

--- a/skills/nelson/scripts/nelson-data.py
+++ b/skills/nelson/scripts/nelson-data.py
@@ -110,7 +110,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915 -- argparse subc
     p_sq.add_argument(
         "--mode",
         default="subagents",
-        help="Execution mode: single-session, subagents, agent-team",
+        help="Execution mode: single-session, subagents, agent-team, workflow, hybrid-workflow",
     )
 
     # --- task ---
@@ -267,7 +267,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915 -- argparse subc
     p_form.add_argument(
         "--mode",
         default="subagents",
-        help="Execution mode: single-session, subagents, agent-team",
+        help="Execution mode: single-session, subagents, agent-team, workflow, hybrid-workflow",
     )
 
     # --- headless ---
@@ -277,7 +277,7 @@ def build_parser() -> argparse.ArgumentParser:  # noqa: PLR0915 -- argparse subc
     p_hl.add_argument(
         "--mode",
         default="subagents",
-        help="Execution mode: single-session, subagents, agent-team",
+        help="Execution mode: single-session, subagents, agent-team, workflow, hybrid-workflow",
     )
     p_hl.add_argument(
         "--auto-approve",

--- a/skills/nelson/scripts/nelson_data_goal.py
+++ b/skills/nelson/scripts/nelson_data_goal.py
@@ -1,0 +1,143 @@
+"""Goal alignment for Nelson missions.
+
+Composes a Claude Code ``/goal`` condition from a mission's sailing orders so
+the harness's session-scoped Stop hook enforces mission completion. The
+``/goal`` evaluator judges the condition against the *conversation transcript*
+only — it does not read files or run commands — so the composed condition is
+phrased in terms of facts the admiral must surface into the conversation
+(metric confirmed, captain's log written and its path stated, stand-down
+recorded), which is exactly what Nelson's Stand Down step already does.
+
+See ``references/goal-alignment.md`` for the doctrine.
+
+No external dependencies — stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from nelson_data_utils import (
+    _append_event,
+    _die,
+    _err,
+    _now_iso,
+    _read_json,
+    _require_mission_dir,
+    _write_json,
+)
+
+# Claude Code caps a /goal condition at 4,000 characters.
+GOAL_CONDITION_MAX_CHARS = 4000
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _clean(text: str) -> str:
+    """Collapse whitespace so free-text fields stay on one line in the condition."""
+    return _WHITESPACE.sub(" ", str(text or "")).strip()
+
+
+def compose_goal_condition(
+    sailing_orders: dict[str, Any],
+    max_turns: int | None = None,
+) -> str:
+    """Compose a transcript-verifiable ``/goal`` condition from sailing orders.
+
+    Pure function: never mutates *sailing_orders*. The returned string is the
+    condition text (without the leading ``/goal``). It is deliberately worded
+    against facts observable in the conversation, because the goal evaluator
+    only sees the transcript.
+    """
+    outcome = _clean(sailing_orders.get("outcome")) or "the stated mission outcome"
+    metric = _clean(sailing_orders.get("success_metric"))
+    stop_criteria = [_clean(c) for c in sailing_orders.get("stop_criteria", []) if _clean(c)]
+
+    conditions: list[str] = []
+    if metric:
+        conditions.append(f"the success metric is confirmed met in this conversation ({metric})")
+    if stop_criteria:
+        conditions.append("every stop criterion is satisfied (" + "; ".join(stop_criteria) + ")")
+    conditions.append(
+        "the captain's log has been written to disk with its path stated here, and Nelson stand-down has been recorded"
+    )
+
+    parts = [
+        f"The Nelson mission is complete: {outcome}.",
+        "Treat this as met only when the conversation shows all of: " + "; ".join(conditions) + ".",
+        (
+            "It is also met if the mission has been formally stood down via scuttle-and-reform "
+            "with the blocking reason stated in this conversation."
+        ),
+    ]
+    if max_turns is not None and max_turns > 0:
+        parts.append(f"Or stop after {max_turns} turns.")
+
+    return " ".join(parts)
+
+
+def _record_goal_condition(mission_dir: Path, condition: str) -> None:
+    """Persist *condition* into sailing-orders.json and log a ``goal_set`` event.
+
+    Immutable update: reads the existing orders, writes a new dict with the
+    added field, and never edits the loaded object in place.
+    """
+    so_path = mission_dir / "sailing-orders.json"
+    if not so_path.exists():
+        _err("Warning: sailing-orders.json not found — goal condition not recorded.")
+        return
+    sailing_orders = _read_json(so_path)
+    new_sailing_orders = {**sailing_orders, "goal_condition": condition}
+    _write_json(so_path, new_sailing_orders)
+    _append_event(
+        mission_dir,
+        {
+            "type": "goal_set",
+            "checkpoint": 0,
+            "timestamp": _now_iso(),
+            "data": {"goal_condition": condition},
+        },
+    )
+
+
+def cmd_goal_condition(args: argparse.Namespace) -> None:
+    """Compose (and optionally record) a ``/goal`` condition from sailing orders."""
+    mission_dir = _require_mission_dir(args)
+
+    so_path = mission_dir / "sailing-orders.json"
+    if not so_path.exists():
+        _die("Error: sailing-orders.json does not exist. Run 'init' before composing a goal.")
+
+    sailing_orders = _read_json(so_path)
+    condition = compose_goal_condition(sailing_orders, max_turns=getattr(args, "max_turns", None))
+
+    char_count = len(condition)
+    within_limit = char_count <= GOAL_CONDITION_MAX_CHARS
+    if not within_limit:
+        _err(
+            f"Warning: composed condition is {char_count} chars, over the {GOAL_CONDITION_MAX_CHARS}-char "
+            "/goal limit. Shorten the outcome, metric, or stop criteria."
+        )
+
+    if getattr(args, "record", False):
+        _record_goal_condition(mission_dir, condition)
+
+    if getattr(args, "json_output", False):
+        print(
+            json.dumps(
+                {
+                    "condition": condition,
+                    "command": f"/goal {condition}",
+                    "char_count": char_count,
+                    "within_limit": within_limit,
+                    "recorded": bool(getattr(args, "record", False)),
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"/goal {condition}")

--- a/skills/nelson/scripts/nelson_data_lifecycle.py
+++ b/skills/nelson/scripts/nelson_data_lifecycle.py
@@ -106,6 +106,19 @@ PHASE_RECOVERY_GUIDANCE: dict[str, list[str]] = {
 
 BATTLE_PLAN_MD_REQUIRED_PHASES: frozenset[str] = frozenset({"BATTLE_PLAN", "FORMATION", "PERMISSION"})
 
+BATTLE_PLAN_ADVISORY_FIELDS: frozenset[str] = frozenset(
+    {
+        "execution_primitive",
+        "workflow_suitability",
+        "workflow_phases",
+        "human_gates",
+        "verification_contract",
+        "cost_guardrail",
+        "fallback_mode",
+        "workflow",
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # Internal helper: _do_init (used by cmd_init and cmd_headless)
@@ -257,7 +270,12 @@ def cmd_squadron(args: argparse.Namespace) -> None:
             }
         )
 
+    if args.mode and args.mode not in VALID_MODES:
+        _die(f"Error: --mode must be one of {sorted(VALID_MODES)}")
+    mode = args.mode or "subagents"
+
     squadron: dict[str, Any] = {
+        "mode": mode,
         "admiral": {
             "ship_name": args.admiral,
             "model": args.admiral_model,
@@ -270,9 +288,6 @@ def cmd_squadron(args: argparse.Namespace) -> None:
             "ship_name": args.red_cell,
             "model": args.red_cell_model or "haiku",
         }
-
-    if args.mode and args.mode not in VALID_MODES:
-        _die(f"Error: --mode must be one of {sorted(VALID_MODES)}")
 
     # Build/update battle-plan.json
     bp_path = mission_dir / "battle-plan.json"
@@ -292,7 +307,7 @@ def cmd_squadron(args: argparse.Namespace) -> None:
         "data": {
             "captain_count": len(captains),
             "has_red_cell": args.red_cell is not None,
-            "execution_mode": args.mode or "subagents",
+            "execution_mode": mode,
             "standing_order_check": {"triggered": [], "remedies": []},
         },
     }
@@ -330,6 +345,7 @@ def cmd_squadron(args: argparse.Namespace) -> None:
             "outcome": None,
             "status": "forming",
             "phase": existing_phase,
+            "execution_mode": mode,
             "started_at": existing_started_at,
             "checkpoint_number": 0,
         },
@@ -1375,6 +1391,7 @@ def _register_squadron(  # noqa: PLR0913 -- args are shaped by the squadron-regi
             **fleet_status.get("mission", {}),
             "outcome": outcome,
             "status": "forming",
+            "execution_mode": mode,
         },
         "squadron": squadron_list,
         "recent_events": [f"Squadron formed: {len(captains)} captains"],
@@ -1622,11 +1639,20 @@ def cmd_handoff(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _validate_plan_json(plan: dict) -> None:  # noqa: C901, PLR0912 -- schema validator with many shape checks; refactor tracked in nelson-e6j
+def _validate_plan_json(plan: dict) -> None:  # noqa: C901, PLR0912, PLR0915 -- schema validator with many shape checks; refactor tracked in nelson-e6j
     """Validate plan JSON structure.  Calls _die on failure."""
+    mode = plan.get("mode")
+    if mode is not None and (not isinstance(mode, str) or mode not in VALID_MODES):
+        _die(f"Error: plan.mode must be one of {sorted(VALID_MODES)}")
+
     if "squadron" not in plan:
         _die("Error: plan JSON must contain a 'squadron' key.")
     sq = plan["squadron"]
+    if not isinstance(sq, dict):
+        _die(f"Error: squadron must be an object; got {type(sq).__name__}.")
+    squadron_mode = sq.get("mode")
+    if squadron_mode is not None and (not isinstance(squadron_mode, str) or squadron_mode not in VALID_MODES):
+        _die(f"Error: squadron.mode must be one of {sorted(VALID_MODES)}")
     if "admiral" not in sq or "captains" not in sq:
         _die("Error: squadron must contain 'admiral' and 'captains'.")
 
@@ -1673,6 +1699,18 @@ def _validate_plan_json(plan: dict) -> None:  # noqa: C901, PLR0912 -- schema va
         if missing:
             _die(f"Error: task {i} is missing required fields: {sorted(missing)}")
 
+    workflow = plan.get("workflow")
+    if workflow is not None:
+        if not isinstance(workflow, dict):
+            _die(f"Error: workflow must be an object when provided; got {type(workflow).__name__}.")
+        phases = workflow.get("phases")
+        if phases is not None:
+            if not isinstance(phases, list):
+                _die("Error: workflow.phases must be an array when provided.")
+            for i, phase in enumerate(phases):
+                if not isinstance(phase, dict):
+                    _die(f"Error: workflow.phases[{i}] must be an object; got {type(phase).__name__}.")
+
 
 def _run_conflict_scan(battle_plan_path: Path) -> dict[str, Any]:
     """Run nelson_conflict_scan.py and return structured result."""
@@ -1700,7 +1738,9 @@ def _do_form(
     """Execute the full formation sequence.  Returns a summary dict."""
     tasks = plan["tasks"]
     sq = plan["squadron"]
-    mode = plan.get("mode", mode)
+    mode = plan.get("mode", sq.get("mode", mode))
+    if mode not in VALID_MODES:
+        _die(f"Error: --mode must be one of {sorted(VALID_MODES)}")
 
     task_records = [
         _build_task_record(
@@ -1719,6 +1759,8 @@ def _do_form(
         )
         for t in tasks
     ]
+
+    _register_plan_advisory_fields(mission_dir, plan)
 
     _err(f"[nelson-data] Registering {len(task_records)} tasks...")
     _register_tasks(mission_dir, task_records)
@@ -1760,6 +1802,27 @@ def _do_form(
         },
         "conflict_scan": scan_result,
     }
+
+
+def _register_plan_advisory_fields(mission_dir: Path, plan: dict[str, Any]) -> None:
+    """Preserve optional battle-plan advisory fields from a composite plan."""
+    advisory = {field: plan[field] for field in BATTLE_PLAN_ADVISORY_FIELDS if field in plan}
+    if not advisory:
+        return
+
+    if "workflow" in advisory:
+        _err("[nelson-data] Preserving workflow charter...")
+    else:
+        _err("[nelson-data] Preserving battle-plan advisory fields...")
+
+    bp_path = mission_dir / "battle-plan.json"
+    if bp_path.exists():
+        battle_plan = _read_json(bp_path)
+    else:
+        battle_plan = {"version": 1}
+
+    new_battle_plan = {**battle_plan, **advisory}
+    _write_json(bp_path, new_battle_plan)
 
 
 def cmd_form(args: argparse.Namespace) -> None:

--- a/skills/nelson/scripts/nelson_data_utils.py
+++ b/skills/nelson/scripts/nelson_data_utils.py
@@ -50,6 +50,11 @@ VALID_EVENT_TYPES = frozenset(
         "circuit_breaker_tripped",
         "estimate_skipped",
         "estimate_outcome_recorded",
+        "workflow_charter_created",
+        "workflow_probe_completed",
+        "workflow_run_started",
+        "workflow_run_completed",
+        "workflow_run_stopped",
     }
 )
 
@@ -65,7 +70,7 @@ VALID_HANDOFF_TYPES = frozenset(
 VALID_DECISIONS = frozenset({"continue", "rescope", "stop"})
 # Admiralty action outcomes — how the admiral ruled on an admiralty action.
 VALID_ADMIRALTY_OUTCOMES = frozenset({"approved", "modified", "rejected"})
-VALID_MODES = frozenset({"single-session", "subagents", "agent-team"})
+VALID_MODES = frozenset({"single-session", "subagents", "agent-team", "workflow", "hybrid-workflow"})
 VALID_ESTIMATE_OUTCOME_STATUSES = frozenset({"pass", "fail", "not-verified"})
 VALID_ESTIMATE_OUTCOME_METHODS = frozenset({"test", "type-check", "lint", "review", "visual"})
 JSON_INDENT = 2

--- a/skills/nelson/scripts/nelson_data_utils.py
+++ b/skills/nelson/scripts/nelson_data_utils.py
@@ -55,6 +55,8 @@ VALID_EVENT_TYPES = frozenset(
         "workflow_run_started",
         "workflow_run_completed",
         "workflow_run_stopped",
+        "goal_set",
+        "goal_cleared",
     }
 )
 

--- a/skills/nelson/scripts/test_nelson_data.py
+++ b/skills/nelson/scripts/test_nelson_data.py
@@ -24,6 +24,7 @@ from nelson_data_lifecycle import (
     BATTLE_PLAN_MD_REQUIRED_PHASES,
     PHASE_RECOVERY_GUIDANCE,
 )
+from nelson_data_utils import VALID_EVENT_TYPES, VALID_MODES
 
 
 def _set_mission_phase(mission_dir: Path, phase: str) -> None:
@@ -206,6 +207,48 @@ class TestSquadron:
         )
         bp = read_json(mission_dir / "battle-plan.json")
         assert bp["squadron"]["red_cell"]["ship_name"] == "HMS Astute"
+
+    def test_workflow_mode_is_valid_and_persisted(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        run(
+            "squadron",
+            "--mission-dir",
+            str(mission_dir),
+            "--admiral",
+            "HMS Victory",
+            "--admiral-model",
+            "opus",
+            "--captain",
+            "HMS Argyll:frigate:sonnet:1",
+            "--mode",
+            "workflow",
+        )
+
+        bp = read_json(mission_dir / "battle-plan.json")
+        fs = read_json(mission_dir / "fleet-status.json")
+        log = read_json(mission_dir / "mission-log.json")
+
+        assert bp["squadron"]["mode"] == "workflow"
+        assert fs["mission"]["execution_mode"] == "workflow"
+        assert log["events"][0]["data"]["execution_mode"] == "workflow"
+
+    def test_invalid_mode_fails(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        result = run(
+            "squadron",
+            "--mission-dir",
+            str(mission_dir),
+            "--admiral",
+            "HMS Victory",
+            "--admiral-model",
+            "opus",
+            "--captain",
+            "HMS Argyll:frigate:sonnet:1",
+            "--mode",
+            "workflow-but-not-really",
+            expect_fail=True,
+        )
+        assert "mode" in result.stderr.lower()
 
     def test_invalid_captain_spec_fails(self, tmp_path: Path) -> None:
         mission_dir = init_mission(tmp_path)
@@ -520,6 +563,74 @@ class TestEstimateOutcome:
 
 
 class TestEvent:
+    def test_valid_event_types_include_workflow_events(self) -> None:
+        assert {
+            "workflow_charter_created",
+            "workflow_probe_completed",
+            "workflow_run_started",
+            "workflow_run_completed",
+            "workflow_run_stopped",
+        } <= VALID_EVENT_TYPES
+
+    def test_workflow_event_types_are_valid(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        for event_type in [
+            "workflow_charter_created",
+            "workflow_probe_completed",
+            "workflow_run_started",
+            "workflow_run_completed",
+            "workflow_run_stopped",
+        ]:
+            run(
+                "event",
+                "--mission-dir",
+                str(mission_dir),
+                "--type",
+                event_type,
+                "--workflow-name",
+                "auth-audit",
+                "--phase",
+                "probe",
+                "--status",
+                "completed",
+                "--agents-total",
+                "3",
+                "--agents-completed",
+                "3",
+                "--tokens-used",
+                "12000",
+                "--elapsed-minutes",
+                "7",
+                "--summary",
+                "stage summary",
+                "--next-gate",
+                "review",
+            )
+
+        log = read_json(mission_dir / "mission-log.json")
+        logged_types = [e["type"] for e in log["events"]]
+        assert logged_types == [
+            "workflow_charter_created",
+            "workflow_probe_completed",
+            "workflow_run_started",
+            "workflow_run_completed",
+            "workflow_run_stopped",
+        ]
+        assert log["events"][1]["data"]["workflow_name"] == "auth-audit"
+        assert log["events"][1]["data"]["agents_total"] == 3
+
+    def test_unknown_workflow_like_event_fails(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        result = run(
+            "event",
+            "--mission-dir",
+            str(mission_dir),
+            "--type",
+            "workflow_magic_happened",
+            expect_fail=True,
+        )
+        assert "invalid event type" in result.stderr.lower() or "workflow_magic_happened" in result.stderr
+
     def test_logs_valid_event(self, tmp_path: Path) -> None:
         mission_dir = init_mission(tmp_path)
         run(
@@ -1079,6 +1190,9 @@ def make_plan(
 
 
 class TestForm:
+    def test_valid_modes_include_workflow_modes(self) -> None:
+        assert {"workflow", "hybrid-workflow"} <= VALID_MODES
+
     def test_form_registers_tasks(self, tmp_path: Path) -> None:
         mission_dir = init_mission(tmp_path)
         plan = make_plan()
@@ -1160,6 +1274,122 @@ class TestForm:
         assert summary["squadron"]["captains"] == 1
         assert summary["squadron"]["mode"] == "subagents"
         assert "conflict_scan" in summary
+
+    def test_form_hybrid_workflow_mode_and_charter_are_persisted(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        workflow = {
+            "suitability": "large fan-out across independent files",
+            "phases": [
+                {
+                    "name": "probe",
+                    "purpose": "Run a small representative slice",
+                    "requires_human_gate_after": True,
+                },
+                {
+                    "name": "full_run",
+                    "purpose": "Run the approved workflow across target scope",
+                    "requires_human_gate_after": False,
+                },
+            ],
+            "verification_contract": [
+                "Findings require independent reviewer confirmation",
+                "Rejected or uncertain findings must be surfaced separately",
+            ],
+            "cost_guardrail": "Run a small slice before full repo scope",
+            "fallback_mode": "agent-team",
+        }
+        plan = {
+            **make_plan(mode="hybrid-workflow"),
+            "execution_primitive": "hybrid-workflow",
+            "workflow_suitability": "large fan-out across independent files",
+            "workflow_phases": workflow["phases"],
+            "human_gates": ["approve after probe"],
+            "verification_contract": workflow["verification_contract"],
+            "cost_guardrail": workflow["cost_guardrail"],
+            "fallback_mode": workflow["fallback_mode"],
+            "workflow": workflow,
+        }
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+
+        result = run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        summary = json.loads(result.stdout)
+        bp = read_json(mission_dir / "battle-plan.json")
+        fs = read_json(mission_dir / "fleet-status.json")
+
+        assert summary["squadron"]["mode"] == "hybrid-workflow"
+        assert bp["squadron"]["mode"] == "hybrid-workflow"
+        assert fs["mission"]["execution_mode"] == "hybrid-workflow"
+        assert bp["workflow"] == workflow
+        assert bp["execution_primitive"] == "hybrid-workflow"
+        assert bp["verification_contract"] == workflow["verification_contract"]
+
+    def test_form_cli_hybrid_workflow_mode_is_persisted(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan()
+        plan.pop("mode")
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+
+        result = run(
+            "form",
+            "--mission-dir",
+            str(mission_dir),
+            "--plan",
+            str(plan_path),
+            "--mode",
+            "hybrid-workflow",
+        )
+        summary = json.loads(result.stdout)
+        bp = read_json(mission_dir / "battle-plan.json")
+        fs = read_json(mission_dir / "fleet-status.json")
+
+        assert summary["squadron"]["mode"] == "hybrid-workflow"
+        assert bp["squadron"]["mode"] == "hybrid-workflow"
+        assert fs["mission"]["execution_mode"] == "hybrid-workflow"
+
+    def test_form_without_workflow_object_remains_valid(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan(mode="subagents")
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+
+        run("form", "--mission-dir", str(mission_dir), "--plan", str(plan_path))
+        bp = read_json(mission_dir / "battle-plan.json")
+        assert "workflow" not in bp
+
+    def test_form_rejects_invalid_workflow_like_mode(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan(mode="workflowish")
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        result = run(
+            "form",
+            "--mission-dir",
+            str(mission_dir),
+            "--plan",
+            str(plan_path),
+            expect_fail=True,
+        )
+        assert "mode" in result.stderr.lower()
+
+    def test_form_cli_invalid_mode_fails(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        plan = make_plan()
+        plan.pop("mode")
+        plan_path = tmp_path / "plan.json"
+        write_plan_json(plan_path, plan)
+        result = run(
+            "form",
+            "--mission-dir",
+            str(mission_dir),
+            "--plan",
+            str(plan_path),
+            "--mode",
+            "workflowish",
+            expect_fail=True,
+        )
+        assert "mode" in result.stderr.lower()
 
     def test_form_missing_plan_fails(self, tmp_path: Path) -> None:
         mission_dir = init_mission(tmp_path)
@@ -1417,6 +1647,42 @@ class TestHeadless:
         assert "sailing_orders" in summary
         assert summary["sailing_orders"]["outcome"] == "Test mission"
         assert "formation" in summary
+
+    def test_headless_preserves_workflow_mode_and_charter(self, tmp_path: Path) -> None:
+        so = make_sailing_orders()
+        workflow = {
+            "suitability": "repeatable review",
+            "phases": [{"name": "full_run", "purpose": "Review all packages"}],
+            "verification_contract": ["Independent reviewer confirmation"],
+            "cost_guardrail": "Stop at 100k tokens",
+            "fallback_mode": "agent-team",
+        }
+        plan = {**make_plan(mode="workflow"), "workflow": workflow}
+        so_path = tmp_path / "sailing-orders.json"
+        plan_path = tmp_path / "plan.json"
+        write_sailing_orders_json(so_path, so)
+        write_plan_json(plan_path, plan)
+
+        result = run(
+            "headless",
+            "--sailing-orders",
+            str(so_path),
+            "--battle-plan",
+            str(plan_path),
+            "--mode",
+            "subagents",
+            "--auto-approve",
+            cwd=tmp_path,
+        )
+
+        summary = json.loads(result.stdout)
+        mission_dir = tmp_path / summary["mission_dir"]
+        bp = read_json(mission_dir / "battle-plan.json")
+        fs = read_json(mission_dir / "fleet-status.json")
+        assert summary["formation"]["squadron"]["mode"] == "workflow"
+        assert bp["squadron"]["mode"] == "workflow"
+        assert bp["workflow"] == workflow
+        assert fs["mission"]["execution_mode"] == "workflow"
 
     def test_headless_missing_sailing_orders_fails(self, tmp_path: Path) -> None:
         plan = make_plan()

--- a/skills/nelson/scripts/test_nelson_data_goal.py
+++ b/skills/nelson/scripts/test_nelson_data_goal.py
@@ -1,0 +1,173 @@
+"""Tests for the goal-condition command and its composer.
+
+Covers the pure ``compose_goal_condition`` function and the ``goal-condition``
+CLI subcommand (plain output, JSON, --record persistence, --max-turns, the
+4,000-char limit warning, and schema preservation of the recorded field).
+Black-box CLI tests go through the same subprocess harness as the other
+nelson-data tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import init_mission, read_json, run
+from nelson_data_goal import GOAL_CONDITION_MAX_CHARS, compose_goal_condition
+from nelson_data_utils import VALID_EVENT_TYPES
+
+# ---------------------------------------------------------------------------
+# Pure composer
+# ---------------------------------------------------------------------------
+
+
+class TestComposeGoalCondition:
+    def test_includes_outcome_and_metric(self) -> None:
+        condition = compose_goal_condition({"outcome": "Ship the auth refactor", "success_metric": "47 tests pass"})
+        assert "Ship the auth refactor" in condition
+        assert "47 tests pass" in condition
+
+    def test_includes_stop_criteria_when_present(self) -> None:
+        condition = compose_goal_condition(
+            {
+                "outcome": "X",
+                "success_metric": "M",
+                "stop_criteria": ["All tests pass", "No regressions"],
+            }
+        )
+        assert "All tests pass" in condition
+        assert "No regressions" in condition
+        assert "every stop criterion" in condition
+
+    def test_omits_stop_criteria_clause_when_absent(self) -> None:
+        condition = compose_goal_condition({"outcome": "X", "success_metric": "M"})
+        assert "every stop criterion" not in condition
+
+    def test_always_requires_captains_log_and_stand_down(self) -> None:
+        """The transcript-verifiable Stand Down evidence is always required."""
+        condition = compose_goal_condition({"outcome": "X"})
+        assert "captain's log" in condition
+        assert "stand-down" in condition.lower()
+
+    def test_includes_scuttle_escape_path(self) -> None:
+        """A formally abandoned mission is a legitimate stop, not a trap."""
+        condition = compose_goal_condition({"outcome": "X"})
+        assert "scuttle-and-reform" in condition
+
+    def test_max_turns_appended(self) -> None:
+        condition = compose_goal_condition({"outcome": "X"}, max_turns=25)
+        assert "stop after 25 turns" in condition
+
+    def test_max_turns_ignored_when_zero_or_none(self) -> None:
+        assert "stop after" not in compose_goal_condition({"outcome": "X"})
+        assert "stop after" not in compose_goal_condition({"outcome": "X"}, max_turns=0)
+
+    def test_missing_outcome_uses_placeholder(self) -> None:
+        condition = compose_goal_condition({})
+        assert "the stated mission outcome" in condition
+
+    def test_collapses_whitespace_in_free_text(self) -> None:
+        condition = compose_goal_condition({"outcome": "line one\n  line two\ttab"})
+        assert "line one line two tab" in condition
+        assert "\n" not in condition
+
+    def test_does_not_mutate_input(self) -> None:
+        orders = {"outcome": "X", "success_metric": "M", "stop_criteria": ["a"]}
+        snapshot = json.dumps(orders, sort_keys=True)
+        compose_goal_condition(orders)
+        assert json.dumps(orders, sort_keys=True) == snapshot
+
+
+# ---------------------------------------------------------------------------
+# CLI: goal-condition
+# ---------------------------------------------------------------------------
+
+
+class TestGoalConditionCommand:
+    def test_plain_output_is_a_goal_command(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        result = run("goal-condition", "--mission-dir", str(mission_dir))
+        assert result.stdout.startswith("/goal ")
+        assert "Test mission" in result.stdout
+        assert "All tests pass" in result.stdout
+
+    def test_json_output_shape(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        result = run("goal-condition", "--mission-dir", str(mission_dir), "--json")
+        payload = json.loads(result.stdout)
+        assert payload["command"] == f"/goal {payload['condition']}"
+        assert payload["char_count"] == len(payload["condition"])
+        assert payload["within_limit"] is True
+        assert payload["recorded"] is False
+
+    def test_max_turns_flows_through(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        result = run("goal-condition", "--mission-dir", str(mission_dir), "--max-turns", "40")
+        assert "stop after 40 turns" in result.stdout
+
+    def test_record_persists_field_and_logs_event(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        run("goal-condition", "--mission-dir", str(mission_dir), "--record")
+
+        so = read_json(mission_dir / "sailing-orders.json")
+        assert "goal_condition" in so
+        assert so["goal_condition"].startswith("The Nelson mission is complete")
+
+        log = read_json(mission_dir / "mission-log.json")
+        assert [e["type"] for e in log["events"]] == ["goal_set"]
+        assert log["events"][0]["data"]["goal_condition"] == so["goal_condition"]
+
+    def test_recorded_field_survives_later_write(self, tmp_path: Path) -> None:
+        """goal_condition must persist through subsequent sailing-orders writes."""
+        mission_dir = init_mission(tmp_path)
+        run("goal-condition", "--mission-dir", str(mission_dir), "--record")
+        run("skip-estimate", "--mission-dir", str(mission_dir), "--reason", "trivial scope")
+
+        so = read_json(mission_dir / "sailing-orders.json")
+        assert "goal_condition" in so
+        assert so["estimate_skipped"] is True
+
+    def test_missing_sailing_orders_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "empty").mkdir()
+        result = run(
+            "goal-condition",
+            "--mission-dir",
+            str(tmp_path / "empty"),
+            cwd=tmp_path,
+            expect_fail=True,
+        )
+        assert "sailing-orders.json" in result.stderr
+
+    def test_over_limit_metric_warns(self, tmp_path: Path) -> None:
+        huge = "x" * (GOAL_CONDITION_MAX_CHARS + 100)
+        mission_dir = init_mission(tmp_path, **{"--metric": huge})
+        result = run("goal-condition", "--mission-dir", str(mission_dir), "--json")
+        payload = json.loads(result.stdout)
+        assert payload["within_limit"] is False
+        assert "over the" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Event types
+# ---------------------------------------------------------------------------
+
+
+class TestGoalEventTypes:
+    def test_goal_events_are_valid(self) -> None:
+        assert "goal_set" in VALID_EVENT_TYPES
+        assert "goal_cleared" in VALID_EVENT_TYPES
+
+    def test_goal_cleared_event_accepted(self, tmp_path: Path) -> None:
+        mission_dir = init_mission(tmp_path)
+        run(
+            "event",
+            "--mission-dir",
+            str(mission_dir),
+            "--type",
+            "goal_cleared",
+            "--reason",
+            "mission complete",
+        )
+        log = read_json(mission_dir / "mission-log.json")
+        assert log["events"][-1]["type"] == "goal_cleared"
+        assert log["events"][-1]["data"]["reason"] == "mission complete"

--- a/skills/nelson/scripts/test_nelson_phase.py
+++ b/skills/nelson/scripts/test_nelson_phase.py
@@ -1323,6 +1323,35 @@ class TestSkillMdEstimateStep:
         assert "elegant" in intro.lower()
 
 
+class TestWorkflowDocumentation:
+    """Structural assertions for dynamic workflow alignment docs."""
+
+    ROOT = Path(__file__).resolve().parents[3]
+    SKILL_MD = ROOT / "skills" / "nelson" / "SKILL.md"
+    README = ROOT / "README.md"
+    SQUADRON = ROOT / "skills" / "nelson" / "references" / "squadron-composition.md"
+    TOOL_MAPPING = ROOT / "skills" / "nelson" / "references" / "tool-mapping.md"
+    WORKFLOW_DOCTRINE = ROOT / "skills" / "nelson" / "references" / "workflow-doctrine.md"
+
+    def test_required_docs_mention_workflow_modes(self) -> None:
+        for path in (self.SKILL_MD, self.README, self.SQUADRON, self.TOOL_MAPPING):
+            text = path.read_text(encoding="utf-8")
+            assert "workflow" in text, f"{path} does not mention workflow"
+            assert "hybrid-workflow" in text, f"{path} does not mention hybrid-workflow"
+
+    def test_workflow_doctrine_covers_core_terms(self) -> None:
+        text = self.WORKFLOW_DOCTRINE.read_text(encoding="utf-8")
+        for phrase in [
+            "Sounding the Channel",
+            "ultracode",
+            "verification contract",
+            "cost",
+            "telemetry",
+            "Station 2/3",
+        ]:
+            assert phrase in text
+
+
 # ---------------------------------------------------------------------------
 # TestEstimateE2E — T9 (happy path) and T10 (opt-out)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements a v1 alignment layer so Nelson understands Claude Code **dynamic workflows** without trying to replace them. Nelson gains two first-class execution modes, supporting doctrine, battle-plan charter fields, structured-data schema additions, and tests.

Nelson v1 **documents and preserves** workflow charters; it does **not** generate or invoke `.claude/workflows/*.js`.

## Execution modes

| Mode | Purpose |
|------|---------|
| `workflow` | One approved autonomous dynamic-workflow run for large fan-out, repeatable review/migration, audits, or cross-checked research. |
| `hybrid-workflow` | Nelson-gated sequence of separate workflow stages with explicit human approval between runs (default for Station 2/3 work). |

`single-session`, `subagents`, and `agent-team` are unchanged. `ultracode` is documented as a Claude Code `xhigh` effort/automation setting, **not** a Nelson mode.

## Changes

**Code**
- `VALID_MODES` += `workflow`, `hybrid-workflow`; CLI `--mode` help updated across `squadron` / `form` / `headless`.
- New mission-log event types: `workflow_charter_created`, `workflow_probe_completed`, `workflow_run_started`, `workflow_run_completed`, `workflow_run_stopped`.
- `squadron` / `form` persist the mode and optional **workflow charter / advisory fields** into `battle-plan.json`; `execution_mode` recorded in `fleet-status.json`. `form` mode precedence: `plan.mode` → `squadron.mode` → CLI `--mode`. Validation for the optional `workflow` object shape.

**Docs / doctrine**
- New `references/workflow-doctrine.md` (suitability, ultracode readiness, "Sounding the Channel" probes, verification contracts, cost controls, telemetry, damage-control mapping).
- Updated `SKILL.md` (Steps 3–7), `README.md` (three → five modes + "Dynamic workflows and ultracode"), `squadron-composition.md`, `tool-mapping.md`, `structured-data.md`, and admiralty templates (`battle-plan.md`, `crew-briefing.md`), plus `docs/project_structure.md`.

## Tests

- Mode persistence (`workflow` / `hybrid-workflow`) and invalid-mode rejection.
- Optional `workflow` schema acceptance + preservation in `battle-plan.json`; existing plan JSON stays valid.
- New workflow event acceptance + unknown-event rejection; `headless` mode preservation.
- Docs/reference assertions for both modes and doctrine; hook test confirming workflow modes are not captain-gated.

## Verification

- `ruff check` ✓ · `ruff format --check` ✓
- `pytest skills/nelson/scripts/` → 396 passed
- `pytest hooks/` → 65 passed · `pytest scripts/` → 21 passed
- `pre-commit run --all-files` ✓ · `scripts/check-references.sh` ✓
